### PR TITLE
Add read-only backtest UI wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ For live market data via [bandl](https://bandl.io) (recommended):
 pip install stolgo bandl
 ```
 
-Optional extras: `pip install stolgo[numba]` for faster sweeps.
+Optional extras:
+
+```bash
+pip install "stolgo[numba]"   # faster sweeps
+pip install "stolgo[ui]"      # local read-only backtest browser
+```
+
+See [docs/UI.md](docs/UI.md) for the local backtest UI, its read-only API, and
+security notes.
 
 ---
 

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1,0 +1,103 @@
+# Stolgo UI
+
+The Stolgo UI is a local, read-only browser for completed backtest and sweep
+exports. It is designed for reviewing artifacts produced by `export_all()` and
+`export_sweep()`, not for starting live trading or placing orders.
+
+## Install
+
+The UI server dependencies are optional:
+
+```bash
+pip install "stolgo[ui]"
+```
+
+From a source checkout, build the frontend assets once before serving the UI:
+
+```bash
+npm ci --prefix frontend
+npm run build --prefix frontend
+```
+
+`pyarrow` is a base dependency because Parquet export is now part of Stolgo's
+reporting contract. `fastapi`, `uvicorn`, and `duckdb` stay in the `ui` extra.
+
+## Produce a run
+
+Backtests continue to write the existing artifacts, plus a manifest and the
+series files needed by the UI:
+
+```python
+from pathlib import Path
+
+from stolgo.report.exporters import export_all
+
+result = Backtest(MyStrategy(), df, symbol="BTCUSDT", interval="1h").run()
+export_all(result, Path("runs/btcusdt-sma"), strategy_name="BTCUSDT SMA")
+```
+
+By default, `export_all()` writes:
+
+- `summary.json`
+- `trades.csv`
+- `tearsheet.html`
+- `manifest.json`
+- `parquet/trades.parquet`
+- `parquet/equity.parquet`
+- `parquet/positions.parquet` when positions exist
+- `parquet/ohlcv.parquet`
+- `parquet/drawdown.parquet`
+
+Set `STOLGO_PERSIST_SERIES=0` to skip the new OHLCV and drawdown Parquet files:
+
+```bash
+STOLGO_PERSIST_SERIES=0 python examples/trend_breakout_backtest.py
+```
+
+## Serve
+
+```bash
+stolgo serve --runs-dir runs --host 127.0.0.1 --port 8000
+```
+
+The server reconciles completed `*/manifest.json` files into a local DuckDB index
+at startup. Runs published as `*.tmp` remain invisible until the atomic rename
+finishes, so the UI does not browse partially written artifacts.
+
+## API
+
+The API is read-only:
+
+- `GET /api/runs`
+- `GET /api/runs/{id}`
+- `GET /api/runs/{id}/series`
+- `GET /api/runs/{id}/trades`
+- `GET /api/sweeps`
+- `GET /api/sweeps/{id}`
+
+There is intentionally no endpoint that starts a backtest or places orders.
+
+## Security notes
+
+- The UI is intended for local use on `127.0.0.1`.
+- Manifests are treated as untrusted input. The API rejects manifest paths that
+  resolve outside the configured `runs_dir`.
+- Missing or corrupt run artifacts return `409` instead of falling back to fake
+  chart data.
+- Tests use local fixtures and exported artifacts only; they do not call live data
+  APIs.
+
+## Example
+
+The CoinDCX BTCUSDT example exports a UI-ready run:
+
+```bash
+PYTHONPATH=lib .venv/bin/python examples/btc_usdt_coindcx_backtest.py \
+  --output runs/coindcx-btcusdt-sma
+```
+
+Then open it with:
+
+```bash
+stolgo serve --runs-dir runs
+```

--- a/examples/btc_usdt_coindcx_backtest.py
+++ b/examples/btc_usdt_coindcx_backtest.py
@@ -1,0 +1,78 @@
+"""Simple BTCUSDT CoinDCX backtest exported for the Stolgo UI.
+
+Run:
+    PYTHONPATH=lib .venv/bin/python examples/btc_usdt_coindcx_backtest.py --output runs/coindcx-btcusdt-sma
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from stolgo import Backtest, Bandl, Context, Strategy
+from stolgo.report.exporters import export_all
+from stolgo.signals import sma
+
+
+class BtcUsdtSmaTrend(Strategy):
+    fast_period = 12
+    slow_period = 36
+    vector_entry_size_pct = 0.35
+
+    def on_start(self, ctx: Context) -> None:
+        close = ctx.data.close
+        self._fast = sma(close, self.fast_period)
+        self._slow = sma(close, self.slow_period)
+
+    def on_bar(self, ctx: Context) -> None:
+        if ctx.i < self.slow_period:
+            return
+
+        fast = self._fast[ctx.i]
+        slow = self._slow[ctx.i]
+        close = ctx.data.close[-1]
+
+        if ctx.position.flat and fast > slow and close > slow:
+            ctx.buy(size_pct=self.vector_entry_size_pct, tag="sma_trend_entry")
+        elif not ctx.position.flat and (fast < slow or close < slow):
+            ctx.close(tag="sma_trend_exit")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run a simple BTCUSDT CoinDCX SMA backtest.")
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--interval", default="1h")
+    parser.add_argument("--days", type=int, default=120)
+    parser.add_argument("--output", type=Path, default=Path("stolgo_coindcx_btcusdt_output"))
+    args = parser.parse_args(argv)
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=args.days)
+
+    print(f"Loading {args.symbol} {args.interval} from CoinDCX: {start.date()} -> {end.date()}")
+    df = Bandl(provider="crypto", source="coindcx").history(
+        args.symbol,
+        args.interval,
+        start,
+        end,
+    )
+    print(f"Bars: {len(df):,}  {df.index.min()} -> {df.index.max()}")
+
+    result = Backtest(
+        BtcUsdtSmaTrend(),
+        df,
+        symbol=args.symbol,
+        interval=args.interval,
+        cash=100_000,
+        commission=0.001,
+        fill_on="close",
+    ).run()
+
+    print(result.summary())
+    export_all(result, args.output, strategy_name=f"{args.symbol} CoinDCX SMA")
+    print(f"Exported to {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/parameter_sweep.py
+++ b/examples/parameter_sweep.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from stolgo import Context, Strategy, load, parameter_sweep
+from stolgo.report.exporters import export_sweep
 from stolgo.signals import sma
 
 
@@ -26,14 +27,18 @@ class SmaTrend(Strategy):
 if __name__ == "__main__":
     fixture = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "trend_up_300bars.csv"
     df = load(fixture, symbol="TREND")
+    param_grid = {"period": range(10, 20), "x": range(10)}
 
     summary = parameter_sweep(
         lambda p: SmaTrend(period=p["period"]),
-        {"period": range(10, 20), "x": range(10)},
+        param_grid,
         df,
         cash=100_000,
         commission=0.0003,
     )
     best = summary.sort_values("sharpe", ascending=False).iloc[0]
+    out = Path("sma_trend_sweep_output")
+    export_sweep(summary, out, param_grid=param_grid, strategy_name="SmaTrend")
     print(f"Ran {len(summary)} combinations")
     print(f"Best period={int(best['period'])} sharpe={best['sharpe']:.4f} total_return={best['total_return']:.4f}")
+    print(f"Exported sweep to {out.resolve()}")

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.npm-cache/
+*.png
+design-qa.md

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backtesting Dashboard Mock</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1682 @@
+{
+  "name": "stolgo-frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stolgo-frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@vitejs/plugin-react": "5.0.4",
+        "lightweight-charts": "^5.2.0",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "vite": "^6.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
+      "integrity": "sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.4.tgz",
+      "integrity": "sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.38",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.2.0.tgz",
+      "integrity": "sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stolgo-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "vite build",
+    "preview": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "5.0.4",
+    "lightweight-charts": "^5.2.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "vite": "^6.4.3"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { AppNav } from "./components/AppNav";
+import { getRun, getRunSeries, getRunTrades, listRuns, listSweeps } from "./data/client";
+import { ComparePage } from "./pages/ComparePage";
+import { NewBacktestPage } from "./pages/NewBacktestPage";
+import { OptimizationPage } from "./pages/OptimizationPage";
+import { ReportsPage } from "./pages/ReportsPage";
+import { StrategyDetailPage } from "./pages/StrategyDetailPage";
+import { StrategyLibraryPage } from "./pages/StrategyLibraryPage";
+
+const emptyData = { candles: [], volume: [], equity: [], drawdown: [], trades: [] };
+
+export function App() {
+  const [activePage, setActivePage] = useState("library");
+  const [exportState, setExportState] = useState("Export");
+  const [runs, setRuns] = useState([]);
+  const [sweeps, setSweeps] = useState([]);
+  const [selectedRunId, setSelectedRunId] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [data, setData] = useState(emptyData);
+  const [selectedTrade, setSelectedTrade] = useState(null);
+  const [loadingRuns, setLoadingRuns] = useState(true);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [error, setError] = useState("");
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    let alive = true;
+    async function load() {
+      setLoadingRuns(true);
+      try {
+        const [runRows, sweepRows] = await Promise.all([listRuns(), listSweeps()]);
+        if (!alive) return;
+        setRuns(runRows);
+        setSweeps(sweepRows);
+        setSelectedRunId((current) => current ?? runRows[0]?.id ?? null);
+        setError("");
+      } catch (loadError) {
+        if (alive) setError(loadError.message);
+      } finally {
+        if (alive) setLoadingRuns(false);
+      }
+    }
+    load();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRunId) return undefined;
+    let alive = true;
+    async function loadDetail() {
+      setLoadingDetail(true);
+      setSelectedTrade(null);
+      try {
+        const runDetail = await getRun(selectedRunId);
+        const [seriesResult, tradesResult] = await Promise.allSettled([
+          getRunSeries(selectedRunId),
+          getRunTrades(selectedRunId),
+        ]);
+        if (!alive) return;
+        const series = seriesResult.status === "fulfilled" ? seriesResult.value : emptyData;
+        const trades = tradesResult.status === "fulfilled" ? tradesResult.value : [];
+        const nextData = {
+          candles: series.candles ?? [],
+          volume: series.volume ?? [],
+          equity: series.equity ?? [],
+          drawdown: series.drawdown ?? [],
+          trades,
+        };
+        setDetail(runDetail);
+        setData(nextData);
+        setSelectedTrade(trades[0] ?? null);
+        setError("");
+      } catch (loadError) {
+        if (!alive) return;
+        setDetail(null);
+        setData(emptyData);
+        setError(loadError.message);
+      } finally {
+        if (alive) setLoadingDetail(false);
+      }
+    }
+    loadDetail();
+    return () => {
+      alive = false;
+    };
+  }, [selectedRunId]);
+
+  const navigateToDetail = (runId) => {
+    setSelectedRunId(runId);
+    setActivePage("detail");
+  };
+
+  const handleExport = () => {
+    setExportState("Queued");
+    window.setTimeout(() => setExportState("Export"), 1800);
+  };
+
+  const pages = {
+    library: <StrategyLibraryPage loading={loadingRuns} onOpenDetail={navigateToDetail} runs={runs} />,
+    detail: (
+      <StrategyDetailPage
+        data={data}
+        detail={detail}
+        loading={loadingDetail}
+        runs={runs}
+        selectedRunId={selectedRunId}
+        selectedTrade={selectedTrade}
+        setSelectedRunId={setSelectedRunId}
+        setSelectedTrade={setSelectedTrade}
+        theme={theme}
+      />
+    ),
+    new: <NewBacktestPage />,
+    compare: <ComparePage onOpenDetail={navigateToDetail} runs={runs} />,
+    optimize: <OptimizationPage sweeps={sweeps} />,
+    reports: <ReportsPage runs={runs} />,
+  };
+
+  return (
+    <main className={`app-shell ${theme}`}>
+      <AppNav
+        activePage={activePage}
+        exportState={exportState}
+        onExport={handleExport}
+        onNavigate={setActivePage}
+        onToggleTheme={() => setTheme((current) => (current === "light" ? "dark" : "light"))}
+        theme={theme}
+      />
+      {error && <div className="app-error">API error: {error}</div>}
+      <div className="page-stage">{pages[activePage]}</div>
+    </main>
+  );
+}

--- a/frontend/src/components/AppNav.jsx
+++ b/frontend/src/components/AppNav.jsx
@@ -1,0 +1,30 @@
+import { navItems } from "../data/constants";
+
+export function AppNav({ activePage, exportState, onExport, onNavigate, onToggleTheme, theme }) {
+  return (
+    <header className="app-nav">
+      <button className="brand-lockup" type="button" onClick={() => onNavigate("library")}>
+        <span className="status-orb" />
+        <div>
+          <b>Stolgo</b>
+          <span>Backtesting workspace</span>
+        </div>
+      </button>
+      <nav className="page-tabs" aria-label="Main pages">
+        {navItems.map(([id, label]) => (
+          <button className={activePage === id ? "active" : ""} key={id} type="button" onClick={() => onNavigate(id)}>
+            {label}
+          </button>
+        ))}
+      </nav>
+      <div className="header-actions">
+        <button className="ghost-button" type="button" onClick={onExport}>
+          {exportState}
+        </button>
+        <button className="theme-toggle" type="button" onClick={onToggleTheme}>
+          {theme === "light" ? "Light" : "Dark"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/MetricCard.jsx
+++ b/frontend/src/components/MetricCard.jsx
@@ -1,0 +1,12 @@
+import { metricTone, metricValue } from "../utils/formatters";
+
+export function MetricCard({ metric }) {
+  const tone = metricTone(metric.value, metric.fmt);
+
+  return (
+    <div className="metric-card">
+      <div className="metric-label">{metric.label}</div>
+      <div className={`metric-value ${tone}`}>{metricValue(metric.value, metric.fmt)}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/PageHeader.jsx
+++ b/frontend/src/components/PageHeader.jsx
@@ -1,0 +1,12 @@
+export function PageHeader({ eyebrow, title, description, action }) {
+  return (
+    <section className="page-header">
+      <div>
+        <span>{eyebrow}</span>
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </div>
+      {action ? <div className="page-header-action">{action}</div> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/charts/TradingCharts.jsx
+++ b/frontend/src/components/charts/TradingCharts.jsx
@@ -1,0 +1,344 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  AreaSeries,
+  CandlestickSeries,
+  ColorType,
+  CrosshairMode,
+  HistogramSeries,
+  createChart,
+  createSeriesMarkers,
+} from "lightweight-charts";
+import { chartColors } from "../../data/constants";
+import { dateLabel, money, percent, price, timeLabel } from "../../utils/formatters";
+
+export function TradingCharts({ data, metrics, onSelectTrade, run, selectedTrade, theme }) {
+  const priceRef = useRef(null);
+  const equityRef = useRef(null);
+  const drawdownRef = useRef(null);
+  const overlayRef = useRef(null);
+  const chartsRef = useRef(null);
+  const [tooltip, setTooltip] = useState(null);
+  const [drawing, setDrawing] = useState(null);
+  const [tools, setTools] = useState({ crosshair: true, tradePath: true });
+
+  useEffect(() => {
+    if (!priceRef.current || !equityRef.current || !drawdownRef.current) return undefined;
+    const chartTheme = theme === "dark"
+      ? {
+          panel: "#101820",
+          text: "#98a5b2",
+          grid: "rgba(226, 236, 244, 0.045)",
+          border: "rgba(226, 236, 244, 0.07)",
+        }
+      : {
+          panel: "#fbfcfd",
+          text: chartColors.muted,
+          grid: chartColors.grid,
+          border: "rgba(23, 33, 43, 0.07)",
+        };
+    let syncing = false;
+
+    const baseOptions = {
+      autoSize: true,
+      layout: {
+        background: { type: ColorType.Solid, color: chartTheme.panel },
+        textColor: chartTheme.text,
+        fontFamily: "IBM Plex Sans",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: chartTheme.grid },
+        horzLines: { color: chartTheme.grid },
+      },
+      rightPriceScale: {
+        borderColor: chartTheme.border,
+        scaleMargins: { top: 0.12, bottom: 0.18 },
+      },
+      timeScale: {
+        borderColor: chartTheme.border,
+        timeVisible: true,
+        secondsVisible: false,
+        tickMarkFormatter: (time) => timeLabel(time),
+      },
+      crosshair: {
+        mode: tools.crosshair ? CrosshairMode.Normal : CrosshairMode.Magnet,
+        vertLine: { color: "rgba(15, 142, 168, 0.72)", style: 2, width: 1 },
+        horzLine: { color: "rgba(15, 142, 168, 0.42)", style: 2, width: 1 },
+      },
+      handleScroll: true,
+      handleScale: true,
+    };
+
+    const priceChart = createChart(priceRef.current, {
+      ...baseOptions,
+      localization: {
+        priceFormatter: (value) => price(value),
+        timeFormatter: (time) => `${dateLabel(time)} ET`,
+      },
+    });
+    const candleSeries = priceChart.addSeries(CandlestickSeries, {
+      upColor: chartColors.green,
+      downColor: chartColors.red,
+      wickUpColor: chartColors.green,
+      wickDownColor: chartColors.red,
+      borderVisible: false,
+      priceFormat: { type: "price", precision: 2, minMove: 0.01 },
+    });
+    candleSeries.setData(data.candles);
+
+    const volumeSeries = priceChart.addSeries(HistogramSeries, {
+      priceScaleId: "",
+      priceFormat: { type: "volume" },
+      base: 0,
+    });
+    volumeSeries.setData(data.volume);
+    volumeSeries.priceScale().applyOptions({ scaleMargins: { top: 0.82, bottom: 0 } });
+
+    createSeriesMarkers(
+      candleSeries,
+      data.trades.flatMap((trade) => [
+        {
+          time: trade.entryTime,
+          position: trade.side === "Long" ? "belowBar" : "aboveBar",
+          color: trade.side === "Long" ? chartColors.green : chartColors.red,
+          shape: trade.side === "Long" ? "arrowUp" : "arrowDown",
+          text: trade.side,
+        },
+        {
+          time: trade.exitTime,
+          position: trade.side === "Long" ? "aboveBar" : "belowBar",
+          color: trade.pnl >= 0 ? chartColors.green : chartColors.red,
+          shape: "circle",
+          text: "Exit",
+        },
+      ]),
+    );
+
+    const equityChart = createChart(equityRef.current, {
+      ...baseOptions,
+      height: 110,
+      rightPriceScale: {
+        borderColor: chartTheme.border,
+        scaleMargins: { top: 0.15, bottom: 0.12 },
+      },
+    });
+    const equitySeries = equityChart.addSeries(AreaSeries, {
+      lineColor: chartColors.green,
+      topColor: chartColors.greenSoft,
+      bottomColor: "rgba(20, 154, 90, 0.02)",
+      lineWidth: 2,
+      priceFormat: { type: "price", precision: 0, minMove: 1 },
+    });
+    equitySeries.setData(data.equity);
+
+    const drawdownChart = createChart(drawdownRef.current, {
+      ...baseOptions,
+      height: 94,
+      rightPriceScale: {
+        borderColor: chartTheme.border,
+        scaleMargins: { top: 0.12, bottom: 0.18 },
+      },
+      localization: { priceFormatter: (value) => `${value.toFixed(0)}%` },
+    });
+    const drawdownSeries = drawdownChart.addSeries(AreaSeries, {
+      lineColor: chartColors.red,
+      topColor: "rgba(200, 63, 58, 0.02)",
+      bottomColor: chartColors.redSoft,
+      lineWidth: 2,
+      priceFormat: { type: "price", precision: 1, minMove: 0.1 },
+    });
+    drawdownSeries.setData(data.drawdown);
+
+    const updateDrawing = () => {
+      const trade = selectedTradeRef.current;
+      if (!trade || !overlayRef.current) return;
+      const x1 = priceChart.timeScale().timeToCoordinate(trade.entryTime);
+      const x2 = priceChart.timeScale().timeToCoordinate(trade.exitTime);
+      const y1 = candleSeries.priceToCoordinate(trade.entryPrice);
+      const y2 = candleSeries.priceToCoordinate(trade.exitPrice);
+      if ([x1, x2, y1, y2].some((point) => point === null)) return;
+
+      const left = Math.min(x1, x2);
+      const top = Math.min(y1, y2);
+      const width = Math.max(1, Math.abs(x2 - x1));
+      const height = Math.max(1, Math.abs(y2 - y1));
+      const length = Math.sqrt(width ** 2 + height ** 2);
+      const angle = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI;
+
+      setDrawing({
+        region: {
+          left,
+          top,
+          width,
+          height,
+          borderColor: trade.pnl >= 0 ? chartColors.green : chartColors.red,
+          background: trade.pnl >= 0 ? chartColors.greenSoft : chartColors.redSoft,
+        },
+        line: {
+          left: x1,
+          top: y1,
+          width: length,
+          transform: `rotate(${angle}deg)`,
+          background: trade.pnl >= 0 ? chartColors.cyan : chartColors.red,
+        },
+        entry: { left: x1, top: y1, label: `Entry ${price(trade.entryPrice)}` },
+        exit: { left: x2, top: y2, label: `Exit ${price(trade.exitPrice)}` },
+      });
+    };
+
+    const selectedTradeRef = { current: selectedTrade };
+    const syncRange = (source, targets) => {
+      source.timeScale().subscribeVisibleLogicalRangeChange((range) => {
+        if (!range || syncing) return;
+        syncing = true;
+        targets.forEach((chart) => chart.timeScale().setVisibleLogicalRange(range));
+        syncing = false;
+        requestAnimationFrame(updateDrawing);
+      });
+    };
+
+    chartsRef.current = {
+      priceChart,
+      equityChart,
+      drawdownChart,
+      candleSeries,
+      updateDrawing: () => updateDrawing(),
+      selectedTradeRef,
+    };
+
+    syncRange(priceChart, [equityChart, drawdownChart]);
+    syncRange(equityChart, [priceChart, drawdownChart]);
+    syncRange(drawdownChart, [priceChart, equityChart]);
+
+    priceChart.timeScale().fitContent();
+    equityChart.timeScale().fitContent();
+    drawdownChart.timeScale().fitContent();
+
+    priceChart.subscribeClick((param) => {
+      if (!param.time) return;
+      const nearest = data.trades.reduce((best, trade) => {
+        const distance = Math.min(Math.abs(trade.entryTime - param.time), Math.abs(trade.exitTime - param.time));
+        return distance < best.distance ? { trade, distance } : best;
+      }, { trade: selectedTrade, distance: Number.POSITIVE_INFINITY });
+      if (nearest.distance < 1800 && nearest.trade) onSelectTrade(nearest.trade);
+    });
+
+    priceChart.subscribeCrosshairMove((param) => {
+      if (!param.point || !param.time || !priceRef.current) {
+        setTooltip(null);
+        return;
+      }
+      const candle = data.candles.find((item) => item.time === param.time);
+      if (!candle) return;
+      const hoverTrade = data.trades.find((trade) => param.time >= trade.entryTime && param.time <= trade.exitTime);
+      setTooltip({
+        x: Math.min(param.point.x + 18, priceRef.current.clientWidth - 220),
+        y: Math.max(param.point.y - 16, 16),
+        candle,
+        trade: hoverTrade,
+      });
+    });
+
+    window.addEventListener("resize", updateDrawing);
+    requestAnimationFrame(updateDrawing);
+
+    return () => {
+      window.removeEventListener("resize", updateDrawing);
+      priceChart.remove();
+      equityChart.remove();
+      drawdownChart.remove();
+      chartsRef.current = null;
+    };
+  }, [data, onSelectTrade, selectedTrade, theme, tools.crosshair]);
+
+  useEffect(() => {
+    if (!chartsRef.current) return;
+    chartsRef.current.selectedTradeRef.current = selectedTrade;
+    requestAnimationFrame(chartsRef.current.updateDrawing);
+  }, [selectedTrade]);
+
+  const lastCandle = data.candles.at(-1);
+  const priorCandle = data.candles.at(-2);
+  const finalEquity = data.equity.at(-1)?.value;
+  const currentDrawdown = data.drawdown.at(-1)?.value;
+  const maxDrawdown = data.drawdown.reduce((lowest, point) => Math.min(lowest, point.value), 0);
+  const change = lastCandle && priorCandle ? lastCandle.close - priorCandle.close : 0;
+  const changePct = priorCandle ? change / priorCandle.close : 0;
+
+  return (
+    <section className="chart-stack" aria-label="Strategy chart workspace">
+      <div className="chart-toolbar">
+        <div>
+          <span className="chart-title">{run?.market ?? "-"} {run?.timeframe ?? "-"}</span>
+          {lastCandle && (
+            <>
+              <span className="ohlc">O {price(lastCandle.open)}</span>
+              <span className="ohlc">H {price(lastCandle.high)}</span>
+              <span className="ohlc">L {price(lastCandle.low)}</span>
+              <span className="ohlc">C {price(lastCandle.close)}</span>
+              <span className={change >= 0 ? "positive" : "negative"}>{price(change)} ({percent(changePct)})</span>
+            </>
+          )}
+        </div>
+        <div className="tool-group" aria-label="Chart tools">
+          {["crosshair", "tradePath"].map((tool) => (
+            <button
+              className={tools[tool] ? "active" : ""}
+              key={tool}
+              type="button"
+              onClick={() => setTools((current) => ({ ...current, [tool]: !current[tool] }))}
+            >
+              {tool === "tradePath" ? "Trade path" : tool.charAt(0).toUpperCase() + tool.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="price-chart-wrap">
+        <div className="price-chart" ref={priceRef} />
+        <div className="drawing-layer" ref={overlayRef}>
+          {drawing && tools.tradePath && (
+            <>
+              <div className="trade-region" style={drawing.region} />
+              <div className="trade-line" style={drawing.line} />
+              <div className="trade-point entry-point" style={drawing.entry} />
+              <div className="trade-point exit-point" style={drawing.exit} />
+              <div className="trade-label entry-label" style={drawing.entry}>{drawing.entry.label}</div>
+              <div className="trade-label exit-label" style={drawing.exit}>{drawing.exit.label}</div>
+            </>
+          )}
+        </div>
+        {tooltip && (
+          <div className="chart-tooltip" style={{ left: tooltip.x, top: tooltip.y }}>
+            <div className="tooltip-date">{dateLabel(tooltip.candle.time)}</div>
+            <div><span>Open</span><b>{price(tooltip.candle.open)}</b></div>
+            <div><span>High</span><b>{price(tooltip.candle.high)}</b></div>
+            <div><span>Low</span><b>{price(tooltip.candle.low)}</b></div>
+            <div><span>Close</span><b>{price(tooltip.candle.close)}</b></div>
+            {tooltip.trade && (
+              <div className="tooltip-trade">
+                <strong>Trade {tooltip.trade.id}</strong>
+                <span className={tooltip.trade.pnlClass}>{money(tooltip.trade.pnl)} · {tooltip.trade.r}R</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="subchart">
+        <div className="panel-label">
+          Equity curve
+          {finalEquity !== undefined && <span>Final: {money(finalEquity)}</span>}
+          <strong>Net {percent(metrics?.total_return ?? 0)}</strong>
+        </div>
+        <div className="subchart-canvas" ref={equityRef} />
+      </div>
+      <div className="subchart compact">
+        <div className="panel-label">
+          Drawdown
+          <span>Max: {maxDrawdown.toFixed(2)}%</span>
+          <strong className="negative">Current {(currentDrawdown ?? 0).toFixed(2)}%</strong>
+        </div>
+        <div className="subchart-canvas" ref={drawdownRef} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/detail/RunAnalysisRail.jsx
+++ b/frontend/src/components/detail/RunAnalysisRail.jsx
@@ -1,0 +1,144 @@
+import { dateLabel, money } from "../../utils/formatters";
+
+function Stat({ label, value, tone = "neutral" }) {
+  return (
+    <div className="rail-stat">
+      <span>{label}</span>
+      <strong className={tone}>{value}</strong>
+    </div>
+  );
+}
+
+function signedMoney(value) {
+  return value >= 0 ? money(value) : `-${money(Math.abs(value))}`;
+}
+
+function average(values) {
+  if (!values.length) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function tradeDistribution(trades) {
+  const wins = trades.filter((trade) => trade.pnl > 0);
+  const losses = trades.filter((trade) => trade.pnl < 0);
+  const best = trades.reduce((current, trade) => (trade.pnl > current.pnl ? trade : current), trades[0]);
+  const worst = trades.reduce((current, trade) => (trade.pnl < current.pnl ? trade : current), trades[0]);
+
+  return {
+    wins,
+    losses,
+    best,
+    worst,
+    avgWinner: average(wins.map((trade) => trade.pnl)),
+    avgLoser: average(losses.map((trade) => trade.pnl)),
+  };
+}
+
+function distributionBars(trades) {
+  if (!trades.length) return [];
+  const maxAbs = Math.max(...trades.map((trade) => Math.abs(trade.pnl)), 1);
+  return trades.slice(0, 24).map((trade) => ({
+    id: trade.id,
+    height: Math.max(8, (Math.abs(trade.pnl) / maxAbs) * 58),
+    tone: trade.pnl >= 0 ? "positive" : "negative",
+  }));
+}
+
+function drawdownStats(drawdown) {
+  if (!drawdown.length) return { max: 0, current: 0, underwater: 0 };
+  const max = drawdown.reduce((min, point) => Math.min(min, point.value), 0);
+  const current = drawdown.at(-1)?.value ?? 0;
+  const underwater = drawdown.filter((point) => point.value < 0).length;
+  return { max, current, underwater };
+}
+
+export function RunAnalysisRail({ data, detail, onSelectTrade, run }) {
+  const trades = data.trades ?? [];
+  const candles = data.candles ?? [];
+  const equity = data.equity ?? [];
+  const drawdown = data.drawdown ?? [];
+  const distribution = trades.length ? tradeDistribution(trades) : null;
+  const bars = distributionBars(trades);
+  const dd = drawdownStats(drawdown);
+  const firstCandle = candles[0];
+  const lastCandle = candles.at(-1);
+  const finalEquity = equity.at(-1)?.value;
+
+  return (
+    <aside className="analysis-rail" aria-label="Run analysis">
+      <section className="rail-panel">
+        <div className="rail-heading">
+          <span>Run facts</span>
+          <h2>{run?.market ?? "-"} {run?.timeframe ?? "-"}</h2>
+        </div>
+        <div className="rail-stat-grid">
+          <Stat label="Candles" value={candles.length.toLocaleString()} />
+          <Stat label="Trades" value={trades.length.toLocaleString()} />
+          <Stat label="Final equity" value={finalEquity === undefined ? "-" : money(finalEquity)} />
+          <Stat label="Profit factor" value={Number(detail?.rawMetrics?.profit_factor ?? 0).toFixed(2)} />
+        </div>
+        {firstCandle && lastCandle && (
+          <p className="rail-note">{dateLabel(firstCandle.time)} to {dateLabel(lastCandle.time)}</p>
+        )}
+      </section>
+
+      <section className="rail-panel">
+        <div className="rail-heading">
+          <span>Trade distribution</span>
+          <h2>Realized PnL</h2>
+        </div>
+        {trades.length === 0 ? (
+          <p className="rail-note">No closed trades in this run.</p>
+        ) : (
+          <>
+            <div className="rail-bars" aria-hidden="true">
+              {bars.map((bar) => (
+                <span className={bar.tone} key={bar.id} style={{ height: `${bar.height}px` }} />
+              ))}
+            </div>
+            <div className="rail-stat-grid">
+              <Stat label="Winners" value={distribution.wins.length.toLocaleString()} tone="positive" />
+              <Stat label="Losers" value={distribution.losses.length.toLocaleString()} tone="negative" />
+              <Stat label="Avg winner" value={signedMoney(distribution.avgWinner)} tone="positive" />
+              <Stat label="Avg loser" value={signedMoney(distribution.avgLoser)} tone="negative" />
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="rail-panel">
+        <div className="rail-heading">
+          <span>Drawdown</span>
+          <h2>Equity pressure</h2>
+        </div>
+        <div className="rail-stat-grid">
+          <Stat label="Max" value={`${dd.max.toFixed(2)}%`} tone="negative" />
+          <Stat label="Current" value={`${dd.current.toFixed(2)}%`} tone={dd.current < 0 ? "negative" : "neutral"} />
+          <Stat label="Underwater bars" value={dd.underwater.toLocaleString()} />
+          <Stat label="Equity points" value={equity.length.toLocaleString()} />
+        </div>
+      </section>
+
+      <section className="rail-panel">
+        <div className="rail-heading">
+          <span>Extremes</span>
+          <h2>Best / worst trades</h2>
+        </div>
+        {distribution ? (
+          <div className="extreme-list">
+            <button type="button" onClick={() => onSelectTrade(distribution.best)}>
+              <span>Best trade #{distribution.best.id}</span>
+              <strong className="positive">{signedMoney(distribution.best.pnl)}</strong>
+            </button>
+            <button type="button" onClick={() => onSelectTrade(distribution.worst)}>
+              <span>Worst trade #{distribution.worst.id}</span>
+              <strong className="negative">{signedMoney(distribution.worst.pnl)}</strong>
+            </button>
+          </div>
+        ) : (
+          <p className="rail-note">No trade extremes available.</p>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/frontend/src/components/detail/TradeTable.jsx
+++ b/frontend/src/components/detail/TradeTable.jsx
@@ -1,0 +1,30 @@
+import { dateLabel, money, price } from "../../utils/formatters";
+
+export function TradeTable({ selectedTrade, setSelectedTrade, visibleTrades }) {
+  return (
+    <div className="trade-table-wrap">
+      <table className="trade-table">
+        <thead>
+          <tr>
+            <th>#</th><th>Entry time</th><th>Exit time</th><th>Side</th><th>Entry price</th><th>Exit price</th><th>Qty</th><th>Net PnL</th><th>R</th><th>Tag</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleTrades.map((trade) => (
+            <tr className={selectedTrade?.id === trade.id ? "selected" : ""} key={trade.id} onClick={() => setSelectedTrade(trade)}>
+              <td>{trade.id}</td><td>{dateLabel(trade.entryTime)}</td><td>{dateLabel(trade.exitTime)}</td>
+              <td className={trade.side === "Long" ? "positive" : "negative"}>{trade.side}</td>
+              <td>{price(trade.entryPrice)}</td><td>{price(trade.exitPrice)}</td><td>{trade.qty}</td>
+              <td className={trade.pnlClass}>{money(trade.pnl)}</td><td className={trade.pnlClass}>{trade.r}R</td><td>{trade.tag}</td>
+            </tr>
+          ))}
+          {visibleTrades.length === 0 && (
+            <tr>
+              <td colSpan="10">No trades for this run.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/data/client.js
+++ b/frontend/src/data/client.js
@@ -1,0 +1,20 @@
+const BASE = import.meta.env.VITE_API_BASE ?? "/api";
+
+async function get(path) {
+  const response = await fetch(`${BASE}${path}`);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${path}`);
+  }
+  return response.json();
+}
+
+function items(payload) {
+  return Array.isArray(payload) ? payload : payload.items ?? [];
+}
+
+export const listRuns = async () => items(await get("/runs"));
+export const getRun = (id) => get(`/runs/${id}`);
+export const getRunSeries = (id) => get(`/runs/${id}/series`);
+export const getRunTrades = (id) => get(`/runs/${id}/trades`);
+export const listSweeps = async () => items(await get("/sweeps"));
+export const getSweep = (id) => get(`/sweeps/${id}`);

--- a/frontend/src/data/constants.js
+++ b/frontend/src/data/constants.js
@@ -1,0 +1,19 @@
+export const chartColors = {
+  green: "#149a5a",
+  greenSoft: "rgba(20, 154, 90, 0.18)",
+  red: "#c83f3a",
+  redSoft: "rgba(200, 63, 58, 0.16)",
+  cyan: "#0f8ea8",
+  muted: "#697480",
+  panel: "#ffffff",
+  grid: "rgba(25, 38, 52, 0.045)",
+};
+
+export const navItems = [
+  ["library", "Library"],
+  ["detail", "Detail"],
+  ["new", "New backtest"],
+  ["compare", "Compare"],
+  ["optimize", "Optimization"],
+  ["reports", "Reports"],
+];

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.jsx";
+import "./styles.css";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -1,0 +1,29 @@
+import { PageHeader } from "../components/PageHeader";
+import { percent } from "../utils/formatters";
+
+export function ComparePage({ onOpenDetail, runs }) {
+  return (
+    <div className="page-flow">
+      <PageHeader
+        eyebrow="Compare"
+        title="Compare strategy candidates without opening every chart"
+        description="Normalize performance, risk, and stability across completed runs."
+      />
+      <section className="compare-board surface-panel">
+        {runs.slice(0, 4).map((run) => (
+          <article className="compare-card" key={run.id}>
+            <div><h2>{run.strategy}</h2><span>{run.market} · {run.timeframe}</span></div>
+            <dl>
+              <div><dt>Return</dt><dd className={run.return >= 0 ? "positive" : "negative"}>{percent(run.return)}</dd></div>
+              <div><dt>Sharpe</dt><dd>{Number(run.sharpe).toFixed(2)}</dd></div>
+              <div><dt>Max DD</dt><dd className="negative">{percent(run.drawdown)}</dd></div>
+              <div><dt>Trades</dt><dd>{run.trades.toLocaleString()}</dd></div>
+            </dl>
+            <button type="button" onClick={() => onOpenDetail(run.id)}>Open</button>
+          </article>
+        ))}
+        {runs.length === 0 && <div className="empty-state">No completed runs to compare.</div>}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewBacktestPage.jsx
+++ b/frontend/src/pages/NewBacktestPage.jsx
@@ -1,0 +1,37 @@
+import { PageHeader } from "../components/PageHeader";
+
+const setupFields = ["Strategy", "Instrument", "Timeframe", "Date range", "Initial capital", "Commission", "Slippage", "Position sizing"];
+const setupValues = ["EMA Trend Breakout", "ES", "5m", "2022-01-01 to 2024-12-31", "$100,000", "$2.10 / side", "1 tick", "Fixed risk 0.5%"];
+
+export function NewBacktestPage() {
+  return (
+    <div className="page-flow">
+      <PageHeader
+        eyebrow="New backtest"
+        title="Define the run before seeing results"
+        description="A focused setup flow for market, data range, strategy parameters, fees, slippage, and risk assumptions."
+        action={<button className="primary-button" type="button">Start run</button>}
+      />
+      <div className="setup-grid">
+        <section className="surface-panel setup-main">
+          <h2>Run setup</h2>
+          <div className="form-grid">
+            {setupFields.map((label, index) => (
+              <label key={label}>
+                <span>{label}</span>
+                <input defaultValue={setupValues[index]} />
+              </label>
+            ))}
+          </div>
+        </section>
+        <aside className="surface-panel setup-side">
+          <h2>Pre-run checks</h2>
+          {["Data has no gaps", "Fees included", "No lookahead fields", "Minimum trades target set"].map((item) => (
+            <div className="check-row" key={item}><span />{item}</div>
+          ))}
+          <div className="run-estimate"><b>Estimated runtime</b><strong>42s</strong></div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OptimizationPage.jsx
+++ b/frontend/src/pages/OptimizationPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { PageHeader } from "../components/PageHeader";
+import { getSweep } from "../data/client";
+
+export function OptimizationPage({ sweeps }) {
+  const [selectedSweepId, setSelectedSweepId] = useState("");
+  const [sweep, setSweep] = useState(null);
+
+  useEffect(() => {
+    setSelectedSweepId((current) => current || sweeps[0]?.id || "");
+  }, [sweeps]);
+
+  useEffect(() => {
+    if (!selectedSweepId) return undefined;
+    let alive = true;
+    getSweep(selectedSweepId)
+      .then((payload) => {
+        if (alive) setSweep(payload);
+      })
+      .catch(() => {
+        if (alive) setSweep(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [selectedSweepId]);
+
+  const columns = sweep?.rows?.[0] ? Object.keys(sweep.rows[0]) : [];
+
+  return (
+    <div className="page-flow">
+      <PageHeader
+        eyebrow="Optimization"
+        title="Inspect parameter sweeps without curve fitting blindly"
+        description="Sort the real persisted sweep rows and look for stable parameter regions."
+        action={<button className="primary-button" type="button">Queue sweep</button>}
+      />
+      <div className="optimization-grid single">
+        <section className="surface-panel candidate-panel">
+          <div className="section-heading">
+            <div>
+              <span>Sweep results</span>
+              <h2>{sweep?.strategy ?? "No sweep selected"}</h2>
+            </div>
+            <select value={selectedSweepId} onChange={(event) => setSelectedSweepId(event.target.value)}>
+              {sweeps.map((row) => (
+                <option key={row.id} value={row.id}>{row.strategy} · {row.id}</option>
+              ))}
+            </select>
+          </div>
+          {!sweep && <div className="empty-state">No completed sweeps found.</div>}
+          {sweep && (
+            <div className="trade-table-wrap">
+              <table className="trade-table">
+                <thead>
+                  <tr>{columns.map((column) => <th key={column}>{column}</th>)}</tr>
+                </thead>
+                <tbody>
+                  {sweep.rows.map((row, index) => (
+                    <tr key={index}>
+                      {columns.map((column) => <td key={column}>{String(row[column])}</td>)}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -1,0 +1,24 @@
+import { PageHeader } from "../components/PageHeader";
+
+export function ReportsPage({ runs }) {
+  return (
+    <div className="page-flow">
+      <PageHeader
+        eyebrow="Reports"
+        title="Review completed run artifacts"
+        description="Each listed report is backed by a completed stolgo run manifest."
+        action={<button className="primary-button" type="button">Export report</button>}
+      />
+      <div className="reports-grid">
+        {runs.map((run, index) => (
+          <section className="surface-panel report-tile" key={run.id}>
+            <span>{String(index + 1).padStart(2, "0")}</span>
+            <h2>{run.strategy}</h2>
+            <p>{run.market} · {run.timeframe} · {run.created_at ? new Date(run.created_at).toLocaleString() : "-"}</p>
+          </section>
+        ))}
+        {runs.length === 0 && <div className="empty-state surface-panel">No completed runs found.</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/StrategyDetailPage.jsx
+++ b/frontend/src/pages/StrategyDetailPage.jsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { TradingCharts } from "../components/charts/TradingCharts";
+import { RunAnalysisRail } from "../components/detail/RunAnalysisRail";
+import { TradeTable } from "../components/detail/TradeTable";
+import { MetricCard } from "../components/MetricCard";
+
+export function StrategyDetailPage({
+  data,
+  detail,
+  loading,
+  runs,
+  selectedRunId,
+  selectedTrade,
+  setSelectedRunId,
+  setSelectedTrade,
+  theme,
+}) {
+  const [tradeFilter, setTradeFilter] = useState("All");
+  const selectedRun = runs.find((run) => run.id === selectedRunId);
+
+  const visibleTrades = data.trades.filter((trade) => {
+    if (tradeFilter === "All") return true;
+    if (tradeFilter === "Winners") return trade.pnl > 0;
+    if (tradeFilter === "Losers") return trade.pnl < 0;
+    return trade.side === tradeFilter;
+  });
+
+  return (
+    <>
+      <header className="topbar">
+        <section className="strategy-identity">
+          <div className="status-orb" />
+          <div className="strategy-selector-block">
+            <div className="strategy-line">
+              <label className="strategy-select-label" htmlFor="strategy-switcher">Strategy</label>
+              <select
+                id="strategy-switcher"
+                className="strategy-select"
+                value={selectedRunId ?? ""}
+                onChange={(event) => setSelectedRunId(event.target.value)}
+              >
+                {runs.map((run) => (
+                  <option key={run.id} value={run.id}>{run.strategy}</option>
+                ))}
+              </select>
+              {selectedRun && <span className="version">{selectedRun.id}</span>}
+            </div>
+            <p>{selectedRun ? `${selectedRun.market} · ${selectedRun.timeframe}` : "Select a completed run"}</p>
+          </div>
+        </section>
+      </header>
+
+      <section className="metrics-strip" aria-label="Performance summary">
+        {detail?.metrics.map((metric) => (
+          <MetricCard metric={metric} key={metric.key} />
+        ))}
+      </section>
+
+      {loading && <div className="empty-state surface-panel">Loading run artifacts...</div>}
+      <div className="workspace-grid">
+        <div className="primary-column">
+          <TradingCharts
+            data={data}
+            metrics={detail?.rawMetrics}
+            onSelectTrade={setSelectedTrade}
+            run={selectedRun}
+            selectedTrade={selectedTrade}
+            theme={theme}
+          />
+          <section className="trade-analysis">
+            <div className="section-heading">
+              <div>
+                <span>Executed trades</span>
+                <h2>Trade analysis</h2>
+              </div>
+              <div className="filters" aria-label="Trade filters">
+                {["All", "Long", "Short", "Winners", "Losers"].map((filter) => (
+                  <button
+                    className={tradeFilter === filter ? "active" : ""}
+                    key={filter}
+                    type="button"
+                    onClick={() => setTradeFilter(filter)}
+                  >
+                    {filter}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <TradeTable visibleTrades={visibleTrades} selectedTrade={selectedTrade} setSelectedTrade={setSelectedTrade} />
+          </section>
+        </div>
+        <RunAnalysisRail
+          data={data}
+          detail={detail}
+          onSelectTrade={setSelectedTrade}
+          run={selectedRun}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/StrategyLibraryPage.jsx
+++ b/frontend/src/pages/StrategyLibraryPage.jsx
@@ -1,0 +1,39 @@
+import { PageHeader } from "../components/PageHeader";
+import { percent } from "../utils/formatters";
+
+export function StrategyLibraryPage({ loading, onOpenDetail, runs }) {
+  return (
+    <div className="page-flow">
+      <PageHeader
+        eyebrow="Strategy library"
+        title="Find the strategies worth inspecting"
+        description="Sort by robustness first, then open the few runs that deserve deeper chart review."
+        action={<button className="primary-button" type="button">Run backtest</button>}
+      />
+      <section className="library-toolbar surface-panel">
+        <input aria-label="Search strategies" placeholder="Search strategy, instrument, tag..." />
+        <button type="button">Instrument</button>
+        <button type="button">Timeframe</button>
+        <button type="button">Risk</button>
+        <button type="button">Recently tested</button>
+      </section>
+      <section className="strategy-table surface-panel">
+        <div className="library-row library-head">
+          <span>Strategy</span><span>Market</span><span>Return</span><span>Sharpe</span><span>Drawdown</span><span>Trades</span>
+        </div>
+        {loading && <div className="empty-state">Loading runs...</div>}
+        {!loading && runs.length === 0 && <div className="empty-state">No completed runs found.</div>}
+        {runs.map((run) => (
+          <button className="library-row" key={run.id} type="button" onClick={() => onOpenDetail(run.id)}>
+            <span><b>{run.strategy}</b><em>Last run {run.created_at ? new Date(run.created_at).toLocaleString() : "-"}</em></span>
+            <span>{run.market} · {run.timeframe}</span>
+            <span className={run.return >= 0 ? "positive" : "negative"}>{percent(run.return)}</span>
+            <span>{Number(run.sharpe).toFixed(2)}</span>
+            <span className="negative">{percent(run.drawdown)}</span>
+            <span>{run.trades.toLocaleString()}</span>
+          </button>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,1186 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap");
+
+:root {
+  color: #17212b;
+  background: #f3f5f7;
+  font-family: "IBM Plex Sans", Inter, system-ui, sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button,
+input,
+select,
+table {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+body {
+  margin: 0;
+  min-width: 0;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  background: #f3f5f7;
+}
+
+.app-shell {
+  --page: #f3f5f7;
+  --panel: rgba(255, 255, 255, 0.88);
+  --panel-solid: #ffffff;
+  --panel-soft: rgba(248, 250, 252, 0.82);
+  --panel-strong: #edf2f6;
+  --ink: #17212b;
+  --muted: #687582;
+  --muted-2: #87919c;
+  --line: rgba(23, 33, 43, 0.075);
+  --line-soft: rgba(23, 33, 43, 0.055);
+  --shadow: 0 18px 44px rgba(39, 52, 68, 0.09), 0 1px 0 rgba(255, 255, 255, 0.68) inset;
+  --shadow-soft: 0 10px 30px rgba(39, 52, 68, 0.065);
+  --green: #149a5a;
+  --green-soft: rgba(20, 154, 90, 0.12);
+  --red: #c83f3a;
+  --red-soft: rgba(200, 63, 58, 0.12);
+  --cyan: #0f8ea8;
+  --cyan-soft: rgba(15, 142, 168, 0.12);
+  --amber: #ad7800;
+  min-height: 100vh;
+  padding: 18px;
+  background:
+    radial-gradient(circle at 18% -6%, rgba(15, 142, 168, 0.08), transparent 34%),
+    radial-gradient(circle at 88% 4%, rgba(20, 154, 90, 0.08), transparent 30%),
+    var(--page);
+  color: var(--ink);
+}
+
+.app-shell.dark {
+  --page: #0b1117;
+  --panel: rgba(16, 24, 32, 0.86);
+  --panel-solid: #101820;
+  --panel-soft: rgba(18, 28, 37, 0.72);
+  --panel-strong: #15222d;
+  --ink: #edf3f7;
+  --muted: #98a5b2;
+  --muted-2: #7d8b97;
+  --line: rgba(226, 236, 244, 0.08);
+  --line-soft: rgba(226, 236, 244, 0.055);
+  --shadow: 0 20px 48px rgba(0, 0, 0, 0.34), 0 1px 0 rgba(255, 255, 255, 0.045) inset;
+  --shadow-soft: 0 12px 32px rgba(0, 0, 0, 0.24);
+  --green: #20b86c;
+  --green-soft: rgba(32, 184, 108, 0.16);
+  --red: #ff534d;
+  --red-soft: rgba(255, 83, 77, 0.16);
+  --cyan: #37bed8;
+  --cyan-soft: rgba(55, 190, 216, 0.15);
+  --amber: #d9a300;
+  background:
+    radial-gradient(circle at 18% -8%, rgba(55, 190, 216, 0.1), transparent 34%),
+    radial-gradient(circle at 88% 2%, rgba(32, 184, 108, 0.09), transparent 31%),
+    var(--page);
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  align-items: stretch;
+  margin-bottom: 10px;
+}
+
+.app-nav,
+.strategy-identity,
+.metrics-strip,
+.chart-stack,
+.trade-analysis,
+.surface-panel,
+.page-header {
+  border: 0;
+  border-radius: 16px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.app-nav {
+  position: sticky;
+  top: 12px;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: 220px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 58px;
+  padding: 8px;
+  margin-bottom: 14px;
+}
+
+.brand-lockup {
+  display: flex;
+  gap: 11px;
+  align-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  padding: 7px 8px;
+}
+
+.brand-lockup b,
+.brand-lockup span {
+  display: block;
+}
+
+.brand-lockup b {
+  font-size: 16px;
+  line-height: 1.1;
+}
+
+.brand-lockup span:not(.status-orb) {
+  color: var(--muted);
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.page-tabs {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  overflow: hidden;
+}
+
+.page-tabs button {
+  border: 0;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.page-tabs button:hover,
+.page-tabs button.active {
+  background: var(--cyan-soft);
+  color: var(--cyan);
+}
+
+.page-stage {
+  display: grid;
+  gap: 12px;
+}
+
+.app-error,
+.empty-state {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.app-error {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.empty-state {
+  padding: 18px;
+}
+
+.page-flow {
+  display: grid;
+  gap: 12px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  padding: 20px 22px;
+}
+
+.page-header span,
+.library-head,
+.setup-main label span,
+.report-tile span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.page-header h1 {
+  margin-top: 4px;
+  font-size: 27px;
+  white-space: normal;
+}
+
+.page-header p {
+  color: var(--muted);
+  max-width: 680px;
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.primary-button {
+  border: 0;
+  border-radius: 999px;
+  background: var(--ink);
+  color: var(--page);
+  min-height: 38px;
+  padding: 0 16px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.surface-panel {
+  padding: 14px;
+}
+
+.strategy-identity {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+  padding: 12px 14px;
+}
+
+.status-orb {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--cyan);
+  box-shadow: 0 0 0 5px var(--cyan-soft);
+  flex: 0 0 auto;
+}
+
+.strategy-line {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+  min-width: 0;
+}
+
+.strategy-selector-block {
+  min-width: 0;
+  flex: 1;
+}
+
+.strategy-select-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.strategy-select {
+  min-width: 250px;
+  max-width: 100%;
+  border: 0;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-solid) 70%, var(--panel-strong));
+  color: var(--ink);
+  padding: 8px 34px 8px 10px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.1;
+  outline: 0;
+}
+
+.strategy-select:focus {
+  box-shadow: 0 0 0 3px var(--cyan-soft);
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 18px;
+  letter-spacing: 0;
+  line-height: 1.15;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.version {
+  border: 0;
+  background: var(--panel-soft);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 2px 5px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+}
+
+.strategy-identity p {
+  color: var(--muted);
+  margin-top: 4px;
+  font-size: 12px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ghost-button,
+.theme-toggle,
+.tool-group button,
+.filters button {
+  border: 0;
+  background: color-mix(in srgb, var(--panel-solid) 72%, var(--panel-strong));
+  color: var(--ink);
+  border-radius: 9px;
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 12px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.35) inset, 0 8px 18px rgba(22, 32, 42, 0.06);
+}
+
+.ghost-button:hover,
+.theme-toggle:hover,
+.tool-group button:hover,
+.tool-group button.active,
+.filters button:hover,
+.filters button.active {
+  border-color: var(--cyan);
+  background: var(--cyan-soft);
+  color: var(--cyan);
+}
+
+.metrics-strip {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 12px;
+  padding: 6px;
+}
+
+.library-toolbar {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) repeat(4, auto);
+  gap: 8px;
+  align-items: center;
+}
+
+.library-toolbar input,
+.form-grid input {
+  width: 100%;
+  min-height: 36px;
+  border: 0;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-solid) 62%, var(--panel-strong));
+  color: var(--ink);
+  padding: 0 12px;
+  outline: 0;
+}
+
+.library-toolbar button {
+  border: 0;
+  border-radius: 999px;
+  background: var(--panel-soft);
+  color: var(--muted);
+  min-height: 34px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+.strategy-table {
+  display: grid;
+  padding: 8px;
+  overflow-x: auto;
+}
+
+.library-row {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.35fr) 0.7fr 0.55fr 0.45fr 0.55fr 0.42fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 58px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  padding: 0 10px;
+  font-size: 12px;
+  min-width: 860px;
+}
+
+.library-row:not(.library-head):hover {
+  background: color-mix(in srgb, var(--cyan-soft) 64%, transparent);
+}
+
+.library-row b,
+.library-row em {
+  display: block;
+}
+
+.library-row em {
+  color: var(--muted);
+  font-style: normal;
+  margin-top: 3px;
+}
+
+.library-head {
+  min-height: 34px;
+}
+
+.sparkline {
+  display: flex;
+  gap: 3px;
+  align-items: end;
+  height: 42px;
+}
+
+.sparkline span {
+  width: 5px;
+  border-radius: 999px;
+  background: var(--green);
+  opacity: 0.88;
+}
+
+.sparkline.negative span {
+  background: var(--red);
+}
+
+.setup-grid,
+.optimization-grid {
+  display: grid;
+  grid-template-columns: minmax(680px, 1fr) 360px;
+  gap: 12px;
+  align-items: start;
+}
+
+.optimization-grid.single {
+  grid-template-columns: 1fr;
+}
+
+.setup-main h2,
+.setup-side h2,
+.heatmap-panel h2,
+.candidate-panel h2,
+.matrix-panel h2,
+.report-tile h2,
+.compare-card h2 {
+  font-size: 16px;
+  margin-bottom: 12px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 6px;
+}
+
+.check-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 38px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.check-row span {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--green);
+  box-shadow: 0 0 0 5px var(--green-soft);
+}
+
+.run-estimate {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--panel-soft);
+}
+
+.run-estimate strong {
+  font: 700 24px/1 "IBM Plex Mono", monospace;
+  color: var(--cyan);
+}
+
+.compare-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.compare-card {
+  display: grid;
+  gap: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-solid) 45%, transparent);
+}
+
+.compare-card h2 {
+  margin-bottom: 2px;
+}
+
+.compare-card > div span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.compare-card dl,
+.run-conditions dl {
+  margin: 0;
+}
+
+.compare-card dl {
+  display: grid;
+  gap: 8px;
+}
+
+.compare-card button {
+  justify-self: start;
+  min-height: 30px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--panel-soft);
+  color: var(--ink);
+}
+
+.compare-card dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+dt {
+  color: var(--muted);
+}
+
+dd {
+  margin: 0;
+}
+
+.heatmap {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: 6px;
+  min-height: 360px;
+}
+
+.heatmap span {
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.heatmap .hot {
+  background: color-mix(in srgb, var(--green) 74%, var(--panel-solid));
+}
+
+.heatmap .mid {
+  background: color-mix(in srgb, var(--amber) 48%, var(--panel-solid));
+}
+
+.heatmap .cold {
+  background: color-mix(in srgb, var(--red) 58%, var(--panel-solid));
+}
+
+.candidate-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px 10px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--panel-soft);
+  margin-bottom: 8px;
+}
+
+.candidate-row b {
+  color: var(--green);
+}
+
+.candidate-row em {
+  color: var(--muted);
+  font-style: normal;
+  font-size: 12px;
+}
+
+.reports-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.report-tile {
+  min-height: 160px;
+}
+
+.report-tile h2 {
+  margin-top: 18px;
+}
+
+.report-tile p {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.metric-card {
+  min-width: 0;
+  padding: 10px 12px;
+  border-left: 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-solid) 48%, transparent);
+}
+
+.metric-card:first-child {
+  border-left: 0;
+}
+
+.metric-label,
+.section-heading span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric-value {
+  margin: 4px 0 5px;
+  font: 600 22px/1 "IBM Plex Mono", monospace;
+  letter-spacing: 0;
+}
+
+.positive {
+  color: var(--green) !important;
+}
+
+.negative {
+  color: var(--red) !important;
+}
+
+.neutral {
+  color: var(--ink);
+}
+
+.warning {
+  color: var(--amber);
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(760px, 1fr) 390px;
+  gap: 12px;
+  align-items: start;
+}
+
+.analysis-rail {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.rail-panel {
+  padding: 14px;
+  border-radius: 16px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  min-width: 0;
+}
+
+.rail-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.rail-heading span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.rail-heading h2 {
+  font-size: 14px;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.rail-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.rail-stat {
+  display: grid;
+  gap: 5px;
+  min-height: 58px;
+  padding: 10px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-solid) 48%, transparent);
+}
+
+.rail-stat span,
+.rail-note,
+.extreme-list span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.rail-stat strong {
+  font: 600 17px/1 "IBM Plex Mono", monospace;
+  letter-spacing: 0;
+}
+
+.rail-note {
+  margin-top: 10px;
+  line-height: 1.4;
+}
+
+.rail-bars {
+  display: flex;
+  align-items: end;
+  gap: 3px;
+  height: 72px;
+  padding: 6px 0 12px;
+}
+
+.rail-bars span {
+  flex: 1;
+  min-width: 4px;
+  border-radius: 5px 5px 1px 1px;
+  background: var(--green);
+  opacity: 0.9;
+}
+
+.rail-bars span.negative {
+  background: var(--red);
+}
+
+.extreme-list {
+  display: grid;
+  gap: 8px;
+}
+
+.extreme-list button {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  min-height: 42px;
+  border: 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-solid) 48%, transparent);
+  color: var(--ink);
+  padding: 0 10px;
+  text-align: left;
+}
+
+.primary-column {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.chart-stack {
+  overflow: hidden;
+  min-width: 0;
+}
+
+.chart-toolbar {
+  height: 40px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 0;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--panel-soft) 86%, transparent), transparent);
+  gap: 12px;
+  min-width: 0;
+}
+
+.chart-toolbar > div:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chart-title {
+  font-weight: 700;
+  margin-right: 10px;
+}
+
+.ohlc {
+  color: var(--muted);
+  margin-right: 9px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 12px;
+}
+
+.tool-group {
+  display: flex;
+  gap: 6px;
+}
+
+.tool-group button {
+  min-height: 26px;
+  padding: 0 9px;
+  color: var(--muted);
+  box-shadow: none;
+}
+
+.price-chart-wrap {
+  position: relative;
+  height: 410px;
+  background: var(--panel-solid);
+}
+
+.price-chart,
+.subchart-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.drawing-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.trade-region {
+  position: absolute;
+  border: 1px solid;
+  border-radius: 8px;
+  z-index: 1;
+}
+
+.trade-line {
+  position: absolute;
+  height: 3px;
+  z-index: 2;
+  transform-origin: left center;
+  box-shadow: 0 0 0 5px rgba(15, 142, 168, 0.1);
+}
+
+.trade-point {
+  position: absolute;
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  translate: -5px -5px;
+  background: var(--panel);
+  border: 2px solid var(--cyan);
+  z-index: 3;
+}
+
+.exit-point {
+  border-color: var(--red);
+}
+
+.trade-label {
+  position: absolute;
+  translate: -50% 12px;
+  background: color-mix(in srgb, var(--panel-solid) 94%, transparent);
+  border: 0;
+  border-left: 3px solid var(--cyan);
+  border-radius: 8px;
+  color: var(--ink);
+  padding: 5px 7px;
+  font: 500 11px/1.2 "IBM Plex Mono", monospace;
+  box-shadow: 0 8px 24px rgba(23, 33, 43, 0.12);
+  white-space: nowrap;
+  z-index: 4;
+}
+
+.exit-label {
+  translate: -50% -32px;
+  border-left-color: var(--red);
+}
+
+.reference-level {
+  position: absolute;
+  left: 0;
+  right: 68px;
+  z-index: 0;
+  border-top: 1px dashed color-mix(in srgb, var(--cyan) 62%, transparent);
+  color: var(--cyan);
+  font: 500 10px/1 "IBM Plex Mono", monospace;
+  text-align: right;
+  padding-top: 3px;
+}
+
+.reference-level.resistance {
+  top: 31%;
+}
+
+.reference-level.support {
+  top: 58%;
+  color: var(--amber);
+  border-top-color: color-mix(in srgb, var(--amber) 58%, transparent);
+}
+
+.chart-tooltip {
+  position: absolute;
+  z-index: 4;
+  width: 204px;
+  border: 0;
+  background: color-mix(in srgb, var(--panel-solid) 94%, transparent);
+  box-shadow: 0 14px 34px rgba(23, 33, 43, 0.18);
+  padding: 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.chart-tooltip div:not(.tooltip-date):not(.tooltip-trade) {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+}
+
+.chart-tooltip span {
+  color: var(--muted);
+}
+
+.tooltip-date {
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.tooltip-trade {
+  border-top: 1px solid var(--line-soft);
+  margin-top: 8px;
+  padding-top: 8px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.subchart {
+  height: 126px;
+  border-top: 0;
+  position: relative;
+  box-shadow: 0 -1px 0 var(--line-soft);
+}
+
+.subchart.compact {
+  height: 110px;
+}
+
+.panel-label {
+  position: absolute;
+  z-index: 2;
+  top: 9px;
+  left: 12px;
+  color: var(--ink);
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.panel-label span,
+.panel-label strong {
+  margin-left: 12px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.trade-analysis {
+  padding: 14px;
+  min-width: 0;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  margin-bottom: 10px;
+}
+
+.section-heading h2 {
+  font-size: 16px;
+  line-height: 1.15;
+  margin-top: 2px;
+}
+
+.filters {
+  display: flex;
+  gap: 6px;
+}
+
+.filters button {
+  min-height: 28px;
+}
+
+.filters button.active {
+  color: var(--cyan);
+}
+
+.trade-table-wrap {
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-solid) 54%, transparent);
+}
+
+.trade-table,
+.mini-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.trade-table {
+  min-width: 760px;
+}
+
+th,
+td {
+  text-align: left;
+  white-space: nowrap;
+}
+
+.trade-table th,
+.trade-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line-soft) 70%, transparent);
+  font-size: 12px;
+}
+
+.trade-table th {
+  color: var(--muted);
+  font-weight: 500;
+  background: color-mix(in srgb, var(--panel-soft) 78%, transparent);
+}
+
+.trade-table td {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.trade-table tbody tr {
+  cursor: pointer;
+}
+
+.trade-table tbody tr:hover,
+.trade-table tbody tr.selected {
+  background: color-mix(in srgb, var(--cyan-soft) 78%, transparent);
+}
+
+.trade-table tbody tr.selected {
+  box-shadow: inset 3px 0 0 var(--cyan);
+}
+
+.run-conditions dl {
+  margin: 0;
+  display: grid;
+  gap: 9px;
+}
+
+.run-conditions div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.run-conditions dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.run-conditions dd {
+  margin: 0;
+  font-size: 12px;
+  text-align: right;
+  font-weight: 600;
+}
+
+@media (max-width: 1240px) {
+  body {
+    min-width: 0;
+  }
+
+  .app-shell {
+    padding: 12px;
+  }
+
+  .app-nav {
+    grid-template-columns: 1fr auto;
+  }
+
+  .page-tabs {
+    grid-column: 1 / -1;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .page-tabs button {
+    flex: 0 0 auto;
+  }
+
+  .topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-strip {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-grid,
+  .optimization-grid,
+  .compare-board,
+  .reports-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .library-toolbar {
+    grid-template-columns: minmax(220px, 1fr) repeat(2, auto);
+    overflow-x: auto;
+  }
+
+}
+
+@media (max-width: 860px) {
+  .page-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .metrics-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .price-chart-wrap {
+    height: 360px;
+  }
+}

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,52 @@
+export function money(value) {
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}
+
+export function price(value) {
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function dateLabel(timestamp) {
+  return new Date(timestamp * 1000).toLocaleString("en-US", {
+    month: "short",
+    day: "2-digit",
+    timeZone: "America/New_York",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function timeLabel(timestamp) {
+  return new Date(timestamp * 1000).toLocaleTimeString("en-US", {
+    timeZone: "America/New_York",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function percent(value) {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+export function metricValue(value, fmt) {
+  if (fmt === "pct") return percent(value);
+  if (fmt === "int") return Math.round(value).toLocaleString("en-US");
+  if (fmt === "r") return `${Number(value).toFixed(2)}R`;
+  return Number(value).toFixed(2);
+}
+
+export function metricTone(value, fmt) {
+  if (fmt === "int") return "neutral";
+  if (value > 0) return "positive";
+  if (value < 0) return "negative";
+  return "neutral";
+}

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ["react", "react-dom/client"],
+  },
+  server: {
+    proxy: {
+      "/api": "http://127.0.0.1:8000",
+    },
+    warmup: {
+      clientFiles: ["./src/main.jsx"],
+    },
+  },
+  plugins: [react()],
+});

--- a/lib/stolgo/cli/main.py
+++ b/lib/stolgo/cli/main.py
@@ -1,5 +1,3 @@
-# stolgo agent mistake checklist — docs/IMPLEMENTATION_PLAN_BACKTEST.md §D
-
 """CLI entrypoint — build step 11."""
 
 from __future__ import annotations
@@ -26,6 +24,23 @@ def _load_strategy(path: Path, class_name: str) -> Strategy:
 
 
 def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "serve":
+        parser = argparse.ArgumentParser(description="stolgo local UI server")
+        parser.add_argument("command", choices=["serve"])
+        parser.add_argument("--runs-dir", type=Path, default=Path("runs"))
+        parser.add_argument("--port", type=int, default=8000)
+        parser.add_argument("--host", default="127.0.0.1")
+        args = parser.parse_args(argv)
+
+        import uvicorn
+
+        from stolgo.ui.server import create_app
+
+        app = create_app(args.runs_dir)
+        uvicorn.run(app, host=args.host, port=args.port)
+        return 0
+
     parser = argparse.ArgumentParser(description="stolgo backtest runner (v0.1)")
     parser.add_argument("strategy", type=Path, help="Path to strategy .py file")
     parser.add_argument("--class", dest="class_name", default="Strategy", help="Strategy class name")
@@ -40,7 +55,7 @@ def main(argv: list[str] | None = None) -> int:
     strategy = _load_strategy(args.strategy, args.class_name)
     result = Backtest(strategy, df, cash=args.cash, commission=args.commission).run()
     print(result.summary())
-    export_all(result, args.output)
+    export_all(result, args.output, strategy_name=args.class_name)
     print(f"Wrote tearsheet to {args.output / 'tearsheet.html'}")
     return 0
 

--- a/lib/stolgo/report/__init__.py
+++ b/lib/stolgo/report/__init__.py
@@ -1,4 +1,4 @@
-from stolgo.report.exporters import export_all, export_csv, export_json, export_parquet
+from stolgo.report.exporters import export_all, export_csv, export_json, export_parquet, export_sweep
 from stolgo.report.metrics import compute_metrics
 from stolgo.report.result import RunResult
 from stolgo.report.tearsheet import Report
@@ -13,4 +13,5 @@ __all__ = [
     "export_csv",
     "export_json",
     "export_parquet",
+    "export_sweep",
 ]

--- a/lib/stolgo/report/exporters.py
+++ b/lib/stolgo/report/exporters.py
@@ -1,11 +1,15 @@
-# stolgo agent mistake checklist — docs/IMPLEMENTATION_PLAN_BACKTEST.md §D
-
 """Export RunResult artifacts (HLD §8.4)."""
 
 from __future__ import annotations
 
+import datetime as dt
 import json
+import os
+import shutil
 from pathlib import Path
+from typing import Any
+
+import pandas as pd
 
 from stolgo.report.result import RunResult
 
@@ -13,6 +17,17 @@ from stolgo.report.result import RunResult
 def export_csv(result: RunResult, trades_path: Path) -> None:
     """Write trades only (accounting export)."""
     result.trades.to_csv(trades_path, index=False)
+
+
+def _persist_series_enabled() -> bool:
+    val = os.environ.get("STOLGO_PERSIST_SERIES", "1").strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+def _drawdown_from_equity(equity: pd.Series) -> pd.Series:
+    # Peak-relative drawdown in percent, matching the report metrics basis.
+    peak = equity.cummax()
+    return ((equity - peak) / peak.replace(0, float("nan"))) * 100.0
 
 
 def export_parquet(result: RunResult, directory: Path) -> None:
@@ -23,15 +38,97 @@ def export_parquet(result: RunResult, directory: Path) -> None:
     if not result.positions.empty:
         result.positions.to_parquet(directory / "positions.parquet")
 
+    if _persist_series_enabled():
+        if result.ohlcv is not None and not result.ohlcv.empty:
+            result.ohlcv.to_parquet(directory / "ohlcv.parquet")
+        _drawdown_from_equity(result.equity).to_frame("drawdown").to_parquet(
+            directory / "drawdown.parquet"
+        )
+
+
+def _now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _write_manifest(
+    result: RunResult,
+    directory: Path,
+    *,
+    final_directory: Path | None = None,
+    strategy_name: str | None = None,
+) -> dict[str, Any]:
+    final_directory = final_directory or directory
+    manifest = {
+        "schema_version": 1,
+        "run_id": final_directory.name,
+        "kind": "run",
+        "strategy": strategy_name or result.params.get("strategy", "Unknown"),
+        "params": result.params,
+        "metrics": result.metrics,
+        "created_at": _now_iso(),
+        "path": str(final_directory),
+    }
+    (directory / "manifest.json").write_text(json.dumps(manifest, indent=2, default=str))
+    return manifest
+
+
+def _replace_directory(tmp: Path, directory: Path) -> None:
+    if directory.exists():
+        shutil.rmtree(directory)
+    os.replace(tmp, directory)
+
+
+def _upsert_manifest(manifest: dict[str, Any], directory: Path) -> None:
+    try:
+        from stolgo.ui.index import upsert_run
+    except ImportError:
+        return
+
+    upsert_run(manifest, index_path=directory.parent / "_index.duckdb")
+
 
 def export_json(result: RunResult, path: Path) -> None:
     result.to_json(path)
 
 
-def export_all(result: RunResult, directory: Path) -> None:
+def export_all(result: RunResult, directory: Path, *, strategy_name: str | None = None) -> None:
     """HTML tearsheet + JSON summary + CSV trades + Parquet bundle."""
-    directory.mkdir(parents=True, exist_ok=True)
-    result.report.to_html(directory / "tearsheet.html")
-    export_json(result, directory / "summary.json")
-    export_csv(result, directory / "trades.csv")
-    export_parquet(result, directory / "parquet")
+    directory = Path(directory)
+    tmp = directory.with_name(directory.name + ".tmp")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    tmp.mkdir(parents=True)
+    result.report.to_html(tmp / "tearsheet.html")
+    export_json(result, tmp / "summary.json")
+    export_csv(result, tmp / "trades.csv")
+    export_parquet(result, tmp / "parquet")
+    manifest = _write_manifest(result, tmp, final_directory=directory, strategy_name=strategy_name)
+    _replace_directory(tmp, directory)
+    _upsert_manifest(manifest, directory)
+
+
+def export_sweep(
+    df: pd.DataFrame,
+    directory: Path,
+    *,
+    param_grid: dict[str, Any],
+    strategy_name: str,
+) -> None:
+    directory = Path(directory)
+    tmp = directory.with_name(directory.name + ".tmp")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    tmp.mkdir(parents=True)
+    df.to_parquet(tmp / "results.parquet", index=False)
+    manifest = {
+        "schema_version": 1,
+        "run_id": directory.name,
+        "kind": "sweep",
+        "strategy": strategy_name,
+        "param_grid": {k: list(v) for k, v in param_grid.items()},
+        "created_at": _now_iso(),
+        "path": str(directory),
+    }
+    (tmp / "manifest.json").write_text(json.dumps(manifest, indent=2, default=str))
+    _replace_directory(tmp, directory)
+    _upsert_manifest(manifest, directory)

--- a/lib/stolgo/ui/__init__.py
+++ b/lib/stolgo/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Local UI data and API helpers."""

--- a/lib/stolgo/ui/adapters.py
+++ b/lib/stolgo/ui/adapters.py
@@ -1,0 +1,92 @@
+"""Pure adapters from stolgo artifacts to frontend JSON contracts."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _to_secs(ts) -> int:
+    return int(pd.Timestamp(ts).timestamp())
+
+
+def run_summary(manifest: dict) -> dict:
+    m = manifest.get("metrics", {})
+    p = manifest.get("params", {})
+    return {
+        "id": manifest["run_id"],
+        "strategy": manifest["strategy"],
+        "market": p.get("symbol") or "-",
+        "timeframe": p.get("interval") or "-",
+        "return": m.get("total_return", 0.0),
+        "sharpe": m.get("sharpe", 0.0),
+        "drawdown": m.get("max_drawdown", 0.0),
+        "trades": int(m.get("num_trades", 0)),
+        "created_at": manifest.get("created_at"),
+    }
+
+
+def metric_cards(metrics: dict) -> list[dict]:
+    order = [
+        ("total_return", "Net return", "pct"),
+        ("cagr", "CAGR", "pct"),
+        ("sharpe", "Sharpe", "num"),
+        ("max_drawdown", "Max drawdown", "pct"),
+        ("profit_factor", "Profit factor", "num"),
+        ("hit_rate", "Win rate", "pct"),
+        ("expectancy", "Expectancy", "r"),
+        ("num_trades", "Trades", "int"),
+    ]
+    return [
+        {"key": key, "label": label, "value": metrics.get(key, 0.0), "fmt": fmt}
+        for key, label, fmt in order
+    ]
+
+
+def series(ohlcv_df, equity_s, drawdown_s) -> dict:
+    candles = [
+        {
+            "time": _to_secs(index),
+            "open": float(row.open),
+            "high": float(row.high),
+            "low": float(row.low),
+            "close": float(row.close),
+        }
+        for index, row in ohlcv_df.iterrows()
+    ]
+    volume = [
+        {
+            "time": _to_secs(index),
+            "value": float(row.volume),
+            "color": "rgba(20,154,90,0.18)"
+            if row.close >= row.open
+            else "rgba(200,63,58,0.16)",
+        }
+        for index, row in ohlcv_df.iterrows()
+    ]
+    equity = [{"time": _to_secs(index), "value": float(value)} for index, value in equity_s.items()]
+    drawdown = [
+        {"time": _to_secs(index), "value": float(value)} for index, value in drawdown_s.items()
+    ]
+    return {"candles": candles, "volume": volume, "equity": equity, "drawdown": drawdown}
+
+
+def trades(trades_df) -> list[dict]:
+    out = []
+    for index, row in trades_df.iterrows():
+        pnl = float(row.get("net_pnl", 0.0))
+        out.append(
+            {
+                "id": int(index) + 1,
+                "entryTime": _to_secs(row["entry_ts"]),
+                "exitTime": _to_secs(row["exit_ts"]),
+                "entryPrice": float(row["entry_price"]),
+                "exitPrice": float(row["exit_price"]),
+                "qty": float(row["qty"]),
+                "pnl": pnl,
+                "r": round(float(row.get("r_multiple", 0.0)), 2),
+                "side": "Long",
+                "tag": row.get("tag") or "",
+                "pnlClass": "positive" if pnl >= 0 else "negative",
+            }
+        )
+    return out

--- a/lib/stolgo/ui/index.py
+++ b/lib/stolgo/ui/index.py
@@ -1,0 +1,149 @@
+"""DuckDB-backed materialized index for exported stolgo runs."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+SCHEMA_VERSION = 1
+_DB_LOCK = threading.Lock()
+
+
+DDL = """
+CREATE TABLE IF NOT EXISTS runs_index (
+  schema_version INTEGER,
+  run_id VARCHAR PRIMARY KEY,
+  kind VARCHAR,
+  strategy VARCHAR,
+  params JSON,
+  metrics JSON,
+  created_at TIMESTAMP,
+  path VARCHAR
+);
+"""
+
+
+def default_index_path(runs_dir: Path | str = Path("runs")) -> Path:
+    return Path(runs_dir) / "_index.duckdb"
+
+
+def ensure_schema(index_path: Path | str = default_index_path()) -> None:
+    index_path = Path(index_path)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with _DB_LOCK:
+        con = duckdb.connect(str(index_path))
+        try:
+            con.execute(DDL)
+        finally:
+            con.close()
+
+
+def upsert_run(manifest: dict[str, Any], index_path: Path | str = default_index_path()) -> None:
+    index_path = Path(index_path)
+    ensure_schema(index_path)
+    params = manifest.get("params", manifest.get("param_grid", {}))
+    metrics = manifest.get("metrics", {})
+    row = (
+        int(manifest.get("schema_version", SCHEMA_VERSION)),
+        str(manifest["run_id"]),
+        str(manifest["kind"]),
+        str(manifest.get("strategy", "Unknown")),
+        json.dumps(params, default=str),
+        json.dumps(metrics, default=str),
+        manifest.get("created_at"),
+        str(manifest["path"]),
+    )
+    with _DB_LOCK:
+        con = duckdb.connect(str(index_path))
+        try:
+            con.execute(
+                """
+                INSERT INTO runs_index
+                  (schema_version, run_id, kind, strategy, params, metrics, created_at, path)
+                VALUES (?, ?, ?, ?, ?::JSON, ?::JSON, ?, ?)
+                ON CONFLICT (run_id) DO UPDATE SET
+                  schema_version = excluded.schema_version,
+                  kind = excluded.kind,
+                  strategy = excluded.strategy,
+                  params = excluded.params,
+                  metrics = excluded.metrics,
+                  created_at = excluded.created_at,
+                  path = excluded.path
+                """,
+                row,
+            )
+        finally:
+            con.close()
+
+
+def reconcile(runs_dir: Path | str = Path("runs"), index_path: Path | str | None = None) -> None:
+    runs_dir = Path(runs_dir)
+    index_path = Path(index_path) if index_path is not None else default_index_path(runs_dir)
+    ensure_schema(index_path)
+    for manifest_path in runs_dir.glob("*/manifest.json"):
+        if manifest_path.parent.name.endswith(".tmp"):
+            continue
+        manifest = json.loads(manifest_path.read_text())
+        upsert_run(manifest, index_path=index_path)
+
+
+def list_runs(
+    *,
+    index_path: Path | str = default_index_path(),
+    kind: str | None = None,
+) -> list[dict[str, Any]]:
+    index_path = Path(index_path)
+    if not index_path.exists():
+        return []
+    query = "SELECT schema_version, run_id, kind, strategy, params, metrics, created_at, path FROM runs_index"
+    params: list[Any] = []
+    if kind is not None:
+        query += " WHERE kind = ?"
+        params.append(kind)
+    query += " ORDER BY created_at DESC"
+    with _DB_LOCK:
+        con = duckdb.connect(str(index_path), read_only=True)
+        try:
+            rows = con.execute(query, params).fetchall()
+        finally:
+            con.close()
+    return [_row_to_manifest(row) for row in rows]
+
+
+def get_manifest(run_id: str, *, index_path: Path | str = default_index_path()) -> dict[str, Any] | None:
+    index_path = Path(index_path)
+    if not index_path.exists():
+        return None
+    with _DB_LOCK:
+        con = duckdb.connect(str(index_path), read_only=True)
+        try:
+            row = con.execute(
+                """
+                SELECT schema_version, run_id, kind, strategy, params, metrics, created_at, path
+                FROM runs_index
+                WHERE run_id = ?
+                """,
+                [run_id],
+            ).fetchone()
+        finally:
+            con.close()
+    return _row_to_manifest(row) if row else None
+
+
+def _row_to_manifest(row: tuple[Any, ...]) -> dict[str, Any]:
+    created_at = row[6].isoformat() if hasattr(row[6], "isoformat") else row[6]
+    return {
+        "schema_version": int(row[0]),
+        "run_id": row[1],
+        "kind": row[2],
+        "strategy": row[3],
+        "params": json.loads(row[4]) if row[4] else {},
+        "metrics": json.loads(row[5]) if row[5] else {},
+        "created_at": created_at,
+        "path": row[7],
+    }

--- a/lib/stolgo/ui/server.py
+++ b/lib/stolgo/ui/server.py
@@ -1,0 +1,178 @@
+"""Read-only FastAPI server for exported stolgo runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+
+from stolgo.ui import adapters
+from stolgo.ui import index as runs_index
+
+
+SUPPORTED_SCHEMA_VERSION = 1
+
+
+def create_app(runs_dir: Path | str = Path("runs"), frontend_dist: Path | str | None = None) -> FastAPI:
+    runs_dir = Path(runs_dir)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    index_path = runs_index.default_index_path(runs_dir)
+    runs_index.reconcile(runs_dir, index_path=index_path)
+
+    app = FastAPI(title="stolgo UI", version="1")
+
+    @app.get("/api/runs")
+    def list_runs() -> dict[str, Any]:
+        items = []
+        warnings = 0
+        for manifest in runs_index.list_runs(index_path=index_path, kind="run"):
+            try:
+                manifest = _load_manifest_from_row(
+                    manifest,
+                    expected_kind="run",
+                    runs_dir=runs_dir,
+                )
+                items.append(adapters.run_summary(manifest))
+            except (FileNotFoundError, ValueError, KeyError, json.JSONDecodeError):
+                warnings += 1
+        return {"items": items, "warnings": warnings}
+
+    @app.get("/api/runs/{run_id}")
+    def get_run(run_id: str) -> dict[str, Any]:
+        manifest = _manifest_for_id(run_id, index_path=index_path, expected_kind="run")
+        return {
+            "id": manifest["run_id"],
+            "strategy": manifest["strategy"],
+            "params": manifest.get("params", {}),
+            "metrics": adapters.metric_cards(manifest.get("metrics", {})),
+            "rawMetrics": manifest.get("metrics", {}),
+            "created_at": manifest.get("created_at"),
+        }
+
+    @app.get("/api/runs/{run_id}/series")
+    def get_run_series(run_id: str) -> dict[str, Any]:
+        manifest = _manifest_for_id(run_id, index_path=index_path, expected_kind="run")
+        parquet_dir = Path(manifest["path"]) / "parquet"
+        try:
+            ohlcv = pd.read_parquet(parquet_dir / "ohlcv.parquet")
+            equity = pd.read_parquet(parquet_dir / "equity.parquet")["equity"]
+            drawdown = pd.read_parquet(parquet_dir / "drawdown.parquet")["drawdown"]
+        except Exception as exc:
+            raise HTTPException(status_code=409, detail=f"run series unavailable: {exc}") from exc
+        return adapters.series(ohlcv, equity, drawdown)
+
+    @app.get("/api/runs/{run_id}/trades")
+    def get_run_trades(run_id: str) -> list[dict[str, Any]]:
+        manifest = _manifest_for_id(run_id, index_path=index_path, expected_kind="run")
+        try:
+            trades_df = pd.read_parquet(Path(manifest["path"]) / "parquet" / "trades.parquet")
+        except Exception as exc:
+            raise HTTPException(status_code=409, detail=f"run trades unavailable: {exc}") from exc
+        return adapters.trades(trades_df)
+
+    @app.get("/api/sweeps")
+    def list_sweeps() -> dict[str, Any]:
+        items = []
+        warnings = 0
+        for manifest in runs_index.list_runs(index_path=index_path, kind="sweep"):
+            try:
+                manifest = _load_manifest_from_row(
+                    manifest,
+                    expected_kind="sweep",
+                    runs_dir=runs_dir,
+                )
+                items.append(
+                    {
+                        "id": manifest["run_id"],
+                        "strategy": manifest.get("strategy", "Unknown"),
+                        "param_grid": manifest.get("param_grid", {}),
+                        "created_at": manifest.get("created_at"),
+                        "path": manifest.get("path"),
+                    }
+                )
+            except (FileNotFoundError, ValueError, KeyError, json.JSONDecodeError):
+                warnings += 1
+        return {"items": items, "warnings": warnings}
+
+    @app.get("/api/sweeps/{sweep_id}")
+    def get_sweep(sweep_id: str) -> dict[str, Any]:
+        manifest = _manifest_for_id(sweep_id, index_path=index_path, expected_kind="sweep")
+        try:
+            rows = pd.read_parquet(Path(manifest["path"]) / "results.parquet").to_dict("records")
+        except Exception as exc:
+            raise HTTPException(status_code=409, detail=f"sweep results unavailable: {exc}") from exc
+        return {
+            "id": manifest["run_id"],
+            "strategy": manifest.get("strategy", "Unknown"),
+            "param_grid": manifest.get("param_grid", {}),
+            "rows": rows,
+        }
+
+    dist = Path(frontend_dist) if frontend_dist is not None else _default_frontend_dist()
+    if dist.exists():
+        app.mount("/", StaticFiles(directory=dist, html=True), name="frontend")
+
+    return app
+
+
+def _default_frontend_dist() -> Path:
+    return Path(__file__).resolve().parents[3] / "frontend" / "dist"
+
+
+def _load_manifest_from_row(
+    manifest: dict[str, Any],
+    *,
+    expected_kind: str,
+    runs_dir: Path,
+) -> dict[str, Any]:
+    run_path = _safe_run_path(manifest, runs_dir=runs_dir)
+    manifest_path = run_path / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(manifest_path)
+    loaded = json.loads(manifest_path.read_text())
+    _safe_run_path(loaded, runs_dir=runs_dir)
+    _validate_manifest(loaded, expected_kind=expected_kind)
+    return loaded
+
+
+def _manifest_for_id(
+    run_id: str,
+    *,
+    index_path: Path,
+    expected_kind: str,
+) -> dict[str, Any]:
+    manifest = runs_index.get_manifest(run_id, index_path=index_path)
+    if manifest is None or manifest.get("kind") != expected_kind:
+        raise HTTPException(status_code=404, detail=f"{expected_kind} not found: {run_id}")
+    try:
+        return _load_manifest_from_row(
+            manifest,
+            expected_kind=expected_kind,
+            runs_dir=index_path.parent,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"manifest missing: {run_id}") from exc
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=409, detail=f"manifest unreadable: {run_id}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+def _validate_manifest(manifest: dict[str, Any], *, expected_kind: str) -> None:
+    version = int(manifest.get("schema_version", 0))
+    if version > SUPPORTED_SCHEMA_VERSION:
+        raise ValueError(f"unsupported schema_version {version}")
+    if manifest.get("kind") != expected_kind:
+        raise ValueError(f"expected {expected_kind}, got {manifest.get('kind')}")
+
+
+def _safe_run_path(manifest: dict[str, Any], *, runs_dir: Path) -> Path:
+    run_path = Path(manifest["path"]).resolve()
+    root = runs_dir.resolve()
+    if not run_path.is_relative_to(root):
+        raise ValueError(f"manifest path outside runs_dir: {manifest.get('run_id')}")
+    return run_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,18 @@ dependencies = [
     "pydantic>=2.0",
     "bandl>=0.3",
     "plotly>=5.0",
+    "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]
 numba = ["numba>=0.58"]
 polars = ["polars>=0.20"]
 kaleido = ["kaleido>=0.2"]
+ui = ["fastapi>=0.110", "uvicorn>=0.29", "duckdb>=0.10"]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.1",
-    "pyarrow>=14.0",
 ]
 
 [project.scripts]

--- a/tests/test_report_exporters.py
+++ b/tests/test_report_exporters.py
@@ -1,0 +1,129 @@
+"""Tests for report artifact exporters."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from stolgo.report.exporters import export_all, export_parquet, export_sweep
+from stolgo.report.result import RunResult
+
+
+def _result() -> RunResult:
+    index = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
+    equity = pd.Series([100.0, 110.0, 99.0], index=index)
+    ohlcv = pd.DataFrame(
+        {
+            "open": [100.0, 105.0, 108.0],
+            "high": [106.0, 111.0, 109.0],
+            "low": [99.0, 104.0, 98.0],
+            "close": [105.0, 108.0, 100.0],
+            "volume": [1000.0, 1200.0, 900.0],
+        },
+        index=index,
+    )
+    positions = pd.DataFrame({"qty": [0.0, 1.0, 0.0], "equity": equity}, index=index)
+    return RunResult(
+        params={},
+        trades=pd.DataFrame(),
+        equity=equity,
+        positions=positions,
+        signals=pd.DataFrame(),
+        ohlcv=ohlcv,
+    )
+
+
+def test_export_parquet_persists_ohlcv_and_drawdown_by_default(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("STOLGO_PERSIST_SERIES", raising=False)
+
+    export_parquet(_result(), tmp_path)
+
+    assert (tmp_path / "ohlcv.parquet").exists()
+    assert (tmp_path / "drawdown.parquet").exists()
+    drawdown = pd.read_parquet(tmp_path / "drawdown.parquet")["drawdown"]
+    assert drawdown.to_list() == pytest.approx([0.0, 0.0, -10.0])
+
+
+@pytest.mark.parametrize("flag", ["0", "false", "no", "off"])
+def test_export_parquet_skips_series_when_disabled(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    monkeypatch.setenv("STOLGO_PERSIST_SERIES", flag)
+
+    export_parquet(_result(), tmp_path)
+
+    assert (tmp_path / "trades.parquet").exists()
+    assert (tmp_path / "equity.parquet").exists()
+    assert not (tmp_path / "ohlcv.parquet").exists()
+    assert not (tmp_path / "drawdown.parquet").exists()
+
+
+def test_export_all_writes_manifest_last_and_publishes_atomically(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _result()
+    out = tmp_path / "runs" / "run-1"
+
+    def checked_export_parquet(exported_result: RunResult, directory) -> None:
+        assert exported_result is result
+        assert directory == out.with_name("run-1.tmp") / "parquet"
+        assert out.with_name("run-1.tmp").exists()
+        assert not out.exists()
+        export_parquet(exported_result, directory)
+        assert not (out.with_name("run-1.tmp") / "manifest.json").exists()
+
+    monkeypatch.setattr("stolgo.report.exporters.export_parquet", checked_export_parquet)
+
+    export_all(result, out, strategy_name="TrendBreakout")
+
+    assert out.exists()
+    assert not out.with_name("run-1.tmp").exists()
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["schema_version"] == 1
+    assert manifest["kind"] == "run"
+    assert manifest["run_id"] == "run-1"
+    assert manifest["strategy"] == "TrendBreakout"
+    assert manifest["path"] == str(out)
+    assert "metrics" in manifest
+
+
+def test_export_sweep_writes_results_and_manifest_atomically(tmp_path) -> None:
+    out = tmp_path / "sweeps" / "sweep-1"
+    df = pd.DataFrame({"lookback": [10, 20], "sharpe": [1.2, 1.5]})
+
+    export_sweep(df, out, param_grid={"lookback": [10, 20]}, strategy_name="Momentum")
+
+    assert (out / "results.parquet").exists()
+    assert not out.with_name("sweep-1.tmp").exists()
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["schema_version"] == 1
+    assert manifest["kind"] == "sweep"
+    assert manifest["run_id"] == "sweep-1"
+    assert manifest["strategy"] == "Momentum"
+    assert manifest["param_grid"] == {"lookback": [10, 20]}
+
+
+def test_exports_upsert_parent_index(tmp_path) -> None:
+    run_out = tmp_path / "runs" / "run-1"
+    sweep_out = tmp_path / "runs" / "sweep-1"
+
+    export_all(_result(), run_out, strategy_name="TrendBreakout")
+    export_sweep(
+        pd.DataFrame({"period": [10], "sharpe": [1.2]}),
+        sweep_out,
+        param_grid={"period": [10]},
+        strategy_name="SmaTrend",
+    )
+
+    import duckdb
+
+    con = duckdb.connect(str(tmp_path / "runs" / "_index.duckdb"), read_only=True)
+    try:
+        counts = dict(con.execute("SELECT kind, count(*) FROM runs_index GROUP BY kind").fetchall())
+    finally:
+        con.close()
+    assert counts == {"run": 1, "sweep": 1}

--- a/tests/test_ui_adapters.py
+++ b/tests/test_ui_adapters.py
@@ -1,0 +1,115 @@
+"""Golden-shape tests for UI adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from stolgo.ui import adapters
+
+
+def test_run_summary_and_metric_cards_types() -> None:
+    manifest = {
+        "run_id": "run-1",
+        "strategy": "TrendBreakout",
+        "params": {"symbol": "SYN", "interval": "1d"},
+        "metrics": {
+            "total_return": 0.12,
+            "cagr": 0.03,
+            "sharpe": 1.1,
+            "max_drawdown": -0.04,
+            "profit_factor": 1.8,
+            "hit_rate": 0.55,
+            "expectancy": 12.5,
+            "num_trades": 7,
+        },
+        "created_at": "2026-07-06T10:00:00+00:00",
+    }
+
+    summary = adapters.run_summary(manifest)
+    assert set(summary) == {
+        "id",
+        "strategy",
+        "market",
+        "timeframe",
+        "return",
+        "sharpe",
+        "drawdown",
+        "trades",
+        "created_at",
+    }
+    assert isinstance(summary["trades"], int)
+
+    cards = adapters.metric_cards(manifest["metrics"])
+    assert all(set(card) == {"key", "label", "value", "fmt"} for card in cards)
+    assert len(cards) == 8
+
+
+def test_series_and_trades_match_frontend_mock_shapes(tmp_path) -> None:
+    index = pd.date_range("2024-01-01", periods=2, freq="D", tz="UTC")
+    ohlcv = pd.DataFrame(
+        {
+            "open": [10.0, 11.0],
+            "high": [12.0, 13.0],
+            "low": [9.0, 10.0],
+            "close": [11.0, 10.5],
+            "volume": [100.0, 200.0],
+        },
+        index=index,
+    )
+    equity = pd.Series([100.0, 99.0], index=index)
+    drawdown = pd.Series([0.0, -1.0], index=index)
+    series = adapters.series(ohlcv, equity, drawdown)
+
+    assert set(series) == {"candles", "volume", "equity", "drawdown"}
+    assert set(series["candles"][0]) == {"time", "open", "high", "low", "close"}
+    assert set(series["volume"][0]) == {"time", "value", "color"}
+    assert set(series["equity"][0]) == {"time", "value"}
+    assert set(series["drawdown"][0]) == {"time", "value"}
+    assert isinstance(series["candles"][0]["time"], int)
+
+    trades_df = pd.DataFrame(
+        {
+            "entry_ts": [index[0]],
+            "exit_ts": [index[1]],
+            "entry_price": [11.0],
+            "exit_price": [10.5],
+            "qty": [1.0],
+            "net_pnl": [-0.5],
+            "r_multiple": [-0.25],
+            "tag": ["exit"],
+        }
+    )
+    trades = adapters.trades(trades_df)
+    assert set(trades[0]) == {
+        "id",
+        "entryTime",
+        "exitTime",
+        "entryPrice",
+        "exitPrice",
+        "qty",
+        "pnl",
+        "r",
+        "side",
+        "tag",
+        "pnlClass",
+    }
+    assert trades[0]["side"] == "Long"
+    assert isinstance(trades[0]["entryTime"], int)
+
+
+def test_adapters_read_existing_output_dir_shape() -> None:
+    output = Path("/tmp/stolgo_step2_run")
+    if not output.exists():
+        return
+    manifest = json.loads((output / "manifest.json").read_text())
+    ohlcv = pd.read_parquet(output / "parquet" / "ohlcv.parquet")
+    equity = pd.read_parquet(output / "parquet" / "equity.parquet")["equity"]
+    drawdown = pd.read_parquet(output / "parquet" / "drawdown.parquet")["drawdown"]
+    trades = pd.read_parquet(output / "parquet" / "trades.parquet")
+
+    assert adapters.run_summary(manifest)["id"] == "stolgo_step2_run"
+    assert adapters.series(ohlcv, equity, drawdown)["candles"]
+    assert adapters.trades(trades)

--- a/tests/test_ui_index.py
+++ b/tests/test_ui_index.py
@@ -1,0 +1,85 @@
+"""Tests for the UI run index."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+
+from stolgo.ui import index
+
+
+def _manifest(root: Path, run_id: str, kind: str) -> dict:
+    path = root / run_id
+    path.mkdir(parents=True)
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "kind": kind,
+        "strategy": "TrendBreakout" if kind == "run" else "SmaTrend",
+        "params": {"symbol": "SYN", "interval": "1d"},
+        "metrics": {"total_return": 0.1, "sharpe": 1.2, "max_drawdown": -0.05, "num_trades": 3}
+        if kind == "run"
+        else {},
+        "created_at": "2026-07-06T10:00:00+00:00",
+        "path": str(path),
+    }
+    if kind == "sweep":
+        manifest["param_grid"] = {"period": [10, 20]}
+    (path / "manifest.json").write_text(json.dumps(manifest))
+    return manifest
+
+
+def test_upsert_and_reconcile_rebuild_counts(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    index_path = index.default_index_path(runs_dir)
+    m1 = _manifest(runs_dir, "run-1", "run")
+    m2 = _manifest(runs_dir, "run-2", "run")
+    m3 = _manifest(runs_dir, "sweep-1", "sweep")
+
+    index.upsert_run(m1, index_path=index_path)
+    index.upsert_run(m2, index_path=index_path)
+    index.upsert_run(m3, index_path=index_path)
+
+    con = duckdb.connect(str(index_path), read_only=True)
+    try:
+        counts = dict(con.execute("SELECT kind, count(*) FROM runs_index GROUP BY kind").fetchall())
+    finally:
+        con.close()
+    assert counts == {"run": 2, "sweep": 1}
+
+    index_path.unlink()
+    index.reconcile(runs_dir)
+
+    con = duckdb.connect(str(index_path), read_only=True)
+    try:
+        rebuilt = dict(con.execute("SELECT kind, count(*) FROM runs_index GROUP BY kind").fetchall())
+    finally:
+        con.close()
+    assert rebuilt == {"run": 2, "sweep": 1}
+
+
+def test_list_runs_and_get_manifest_roundtrip_json(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    index_path = index.default_index_path(runs_dir)
+    manifest = _manifest(runs_dir, "run-1", "run")
+    index.upsert_run(manifest, index_path=index_path)
+
+    listed = index.list_runs(index_path=index_path, kind="run")
+    assert len(listed) == 1
+    assert listed[0]["params"]["symbol"] == "SYN"
+    assert listed[0]["metrics"]["sharpe"] == 1.2
+    assert index.get_manifest("run-1", index_path=index_path)["run_id"] == "run-1"
+    assert index.get_manifest("missing", index_path=index_path) is None
+
+
+def test_reconcile_skips_tmp_directories(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    _manifest(runs_dir, "complete", "run")
+    _manifest(runs_dir, "in-progress.tmp", "run")
+
+    index.reconcile(runs_dir)
+
+    listed = index.list_runs(index_path=index.default_index_path(runs_dir), kind="run")
+    assert [row["run_id"] for row in listed] == ["complete"]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,130 @@
+"""Tests for the read-only UI API."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from stolgo.report.exporters import export_all, export_sweep
+from stolgo.report.result import RunResult
+from stolgo.ui.server import create_app
+
+
+def _result() -> RunResult:
+    index = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
+    equity = pd.Series([100.0, 105.0, 102.0], index=index)
+    ohlcv = pd.DataFrame(
+        {
+            "open": [10.0, 11.0, 12.0],
+            "high": [12.0, 13.0, 14.0],
+            "low": [9.0, 10.0, 11.0],
+            "close": [11.0, 12.0, 12.5],
+            "volume": [100.0, 120.0, 130.0],
+        },
+        index=index,
+    )
+    trades = pd.DataFrame(
+        {
+            "entry_ts": [index[0]],
+            "exit_ts": [index[1]],
+            "entry_price": [11.0],
+            "exit_price": [12.0],
+            "qty": [1.0],
+            "net_pnl": [1.0],
+            "tag": ["exit"],
+        }
+    )
+    positions = pd.DataFrame({"qty": [0.0, 1.0, 0.0], "equity": equity}, index=index)
+    return RunResult(
+        params={"symbol": "SYN", "interval": "1d"},
+        trades=trades,
+        equity=equity,
+        positions=positions,
+        signals=pd.DataFrame(),
+        ohlcv=ohlcv,
+    )
+
+
+def _client(tmp_path: Path) -> TestClient:
+    runs_dir = tmp_path / "runs"
+    export_all(_result(), runs_dir / "run-1", strategy_name="TrendBreakout")
+    export_sweep(
+        pd.DataFrame({"period": [10], "sharpe": [1.2]}),
+        runs_dir / "sweep-1",
+        param_grid={"period": [10]},
+        strategy_name="SmaTrend",
+    )
+    return TestClient(create_app(runs_dir))
+
+
+def test_read_only_endpoints_return_adapter_shapes(tmp_path) -> None:
+    client = _client(tmp_path)
+
+    runs = client.get("/api/runs").json()
+    assert runs["warnings"] == 0
+    assert runs["items"][0]["id"] == "run-1"
+
+    detail = client.get("/api/runs/run-1").json()
+    assert detail["strategy"] == "TrendBreakout"
+    assert all(set(card) == {"key", "label", "value", "fmt"} for card in detail["metrics"])
+
+    series = client.get("/api/runs/run-1/series").json()
+    assert set(series) == {"candles", "volume", "equity", "drawdown"}
+    assert isinstance(series["candles"][0]["time"], int)
+
+    trades = client.get("/api/runs/run-1/trades").json()
+    assert trades[0]["side"] == "Long"
+
+    sweeps = client.get("/api/sweeps").json()
+    assert sweeps["items"][0]["id"] == "sweep-1"
+
+    sweep = client.get("/api/sweeps/sweep-1").json()
+    assert sweep["param_grid"] == {"period": [10]}
+    assert sweep["rows"] == [{"period": 10, "sharpe": 1.2}]
+
+
+def test_error_contract_404_409_and_list_warnings(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    export_all(_result(), runs_dir / "run-1", strategy_name="TrendBreakout")
+    client = TestClient(create_app(runs_dir))
+
+    assert client.get("/api/runs/missing").status_code == 404
+
+    (runs_dir / "run-1" / "parquet" / "ohlcv.parquet").unlink()
+    assert client.get("/api/runs/run-1/series").status_code == 409
+
+    bad_dir = runs_dir / "bad"
+    bad_dir.mkdir()
+    bad_manifest = {
+        "schema_version": 99,
+        "run_id": "bad",
+        "kind": "run",
+        "strategy": "Future",
+        "params": {},
+        "metrics": {},
+        "created_at": "2026-07-06T10:00:00+00:00",
+        "path": str(bad_dir),
+    }
+    (bad_dir / "manifest.json").write_text(json.dumps(bad_manifest))
+    client = TestClient(create_app(runs_dir))
+    listing = client.get("/api/runs").json()
+    assert listing["warnings"] == 1
+
+
+def test_manifest_path_must_stay_inside_runs_dir(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    export_all(_result(), runs_dir / "run-1", strategy_name="TrendBreakout")
+    manifest_path = runs_dir / "run-1" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["path"] = str(tmp_path / "outside")
+    manifest_path.write_text(json.dumps(manifest))
+
+    client = TestClient(create_app(runs_dir))
+
+    assert client.get("/api/runs").json()["warnings"] == 1
+    response = client.get("/api/runs/run-1")
+    assert response.status_code == 409
+    assert "outside runs_dir" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Add env-gated OHLCV/drawdown Parquet persistence, atomic run/sweep publish, manifests, and sweep export.
- Add a read-only FastAPI UI backend with DuckDB run index, startup reconcile, schema/error handling, and path containment checks for manifest safety.
- Add a React/Vite frontend wired to real Stolgo run/sweep endpoints, including TradingView lightweight charts, trade table sync, and a real-data analysis rail.
- Add a simple CoinDCX BTCUSDT SMA example that exports a UI-consumable run.
- Add `docs/UI.md` and README installation notes for the local read-only UI.

## Validation
- `.venv/bin/pytest tests/test_report_exporters.py tests/test_ui_index.py tests/test_ui_adapters.py tests/test_ui_server.py tests/test_data_bandl_source.py`
- `npm ci --cache /tmp/stolgo-npm-cache --prefix frontend`
- `npm audit --prefix frontend --audit-level=high --cache /tmp/stolgo-npm-cache`
- `npm run build --prefix frontend`

## Security / OSS hygiene
- Removed generated frontend artifacts from the PR surface (`node_modules`, `dist`, npm caches/logs).
- Updated Vite to `6.4.3` to clear the high-severity audit finding for `vite<=6.4.2`.
- Added server-side manifest path containment so API reads cannot escape the configured `runs_dir`.
- Kept the API read-only; no backtest-trigger endpoint is included.
- Documented local-only usage, read-only endpoints, and artifact error behavior in `docs/UI.md`.

## Notes
- Existing unrelated local changes were left unstaged