### PR TITLE
Add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+# Publish to PyPI using Trusted Publishing (OIDC).
+# Configure the trusted publisher on https://pypi.org (see docs/PYPI_TRUSTED_PUBLISHING.md).
+# Actions are pinned to full SHAs (supply-chain hygiene); bump intentionally when upgrading.
+
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stolgo/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Verify git tag matches pyproject version
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Git tag v${TAG} must match project.version in pyproject.toml (found ${PKG})"
+            exit 1
+          fi
+
+      - name: Install build
+        run: pip install "build>=1.2,<2"
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 @ 2026-02-18


### PR DESCRIPTION
## Summary
- add the missing GitHub Actions trusted-publishing workflow for PyPI
- add repo-specific trusted publishing docs for stolgo
- document the first publish path for the already-tagged `v0.2.0`

## Validation
- `uv run --python /Users/chiranjeev/.local/bin/python3.11 --with build python -m build`

## Release note
After this merges, publish `0.2.0` by running **Publish to PyPI** manually on `master`. The `v0.2.0` tag already exists, so the tag-trigger path will apply starting with the next release tag.